### PR TITLE
Export to SARIF format added

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ $ npm install @doyensec/electronegativity -g
 ```
 
 ## Usage
-|    Option    |                 Description                |
-|:------------:|:------------------------------------------:|
-| -V           | output the version number                  |
-| -i, --input  | input (directory, .js, .htm, .asar)        |
-| -o, --output | save the results in csv format to a file |
-| -h, --help   | output usage information                   |
+|    Option    |                 Description                       |
+|:------------:|:-------------------------------------------------:|
+| -V           | output the version number                         |
+| -i, --input  | input (directory, .js, .htm, .asar)               |
+| -o, --output | save the results to a file in csv or sarif format |
+| -h, --help   | output usage information                          |
 
 ## Examples
 Using electronegativity to look for issues in a directory containing an Electron app:

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 import program from 'commander';
 import path from 'path';
-
+import chalk from 'chalk';
 import run from './runner.js'
 
 console.log(`
@@ -20,7 +20,7 @@ program
   .version('1.0.6')
   .description('Electronegativity is a tool to identify misconfigurations and security anti-patterns in Electron applications.')
   .option('-i, --input <path>', 'input [directory | .js | .html | .asar]')
-  .option('-o, --output <filename>', 'save the results in csv format to a file')
+  .option('-o, --output <filename[.csv | .sarif]>', 'save the results to a file in csv or sarif format')
   .parse(process.argv);
 
 if(!program.input){
@@ -28,6 +28,15 @@ if(!program.input){
   process.exit(1);
 }
 
+if(program.output){
+  program.fileFormat = program.output.split('.').pop();
+  if(program.fileFormat !== 'csv' && program.fileFormat !== 'sarif'){
+    console.log(chalk.red('Please specify file format extension.'));
+    program.outputHelp();
+    process.exit(1);
+  }
+}
+
 const input = path.resolve(program.input);
 
-run(input, program.output);
+run(input, program.output, program.fileFormat === 'sarif');


### PR DESCRIPTION
The issue was already raised in #4 - console window is inconvenient for reviewer, because he has to copy/paste the path and find the line number to verify the warning.

SARIF (Static Analysis Results Interchange Format) allows importing results into compatible application for review. There are extensions for Visual Studio Code and Visual Studio for example.

An example how it looks like in Visual Studio Code:

![image](https://user-images.githubusercontent.com/26652396/46579449-af12b780-ca1a-11e8-88ce-a22e580799e1.png)

1. Open the SARIF file File->Open
2. In the Problems window at the bottom filter by 'electronegativity'.
3. Click on the problem - the file is automatically opened with the issue highlighted. You can walk between problems without mouse by up/down keys. Issues that require manual analysis are displayed as warnings or errors otherwise. Additional information is displayed in Sarif Explorer on the right. The link to github wiki is clickable to read more about the issue.