### PR TITLE
closes #33: Ability to run a single scan check

### DIFF
--- a/src/finder/checks/index.js
+++ b/src/finder/checks/index.js
@@ -27,7 +27,7 @@ import WebSecurityHTMLCheck from './WebSecurityHTMLCheck';
 import WebSecurityJSCheck from './WebSecurityJSCheck';
 
 
-const ENABLED_CHECKS = [
+const CHECKS = [
   AllowPopupsHTMLCheck,
   AuxclickHTMLCheck,
   AuxclickJSCheck,
@@ -57,4 +57,4 @@ const ENABLED_CHECKS = [
   WebSecurityJSCheck,
 ];
 
-module.exports.ENABLED_CHECKS = ENABLED_CHECKS;
+module.exports.CHECKS = CHECKS;

--- a/src/finder/finder.js
+++ b/src/finder/finder.js
@@ -1,9 +1,21 @@
-import { ENABLED_CHECKS } from './checks';
+import { CHECKS } from './checks';
 import { sourceTypes } from '../parser/types';
+import chalk from 'chalk';
 
 export class Finder {
-  constructor() {
-    this._enabled_checks = ENABLED_CHECKS;
+  constructor(customScan) {
+    if (customScan && customScan.length > 0) {
+      var checksNames = CHECKS.map(check => check.name.toLowerCase());
+      if (!customScan.some(r => checksNames.includes(r))) {
+        console.log(chalk.red(`You have an error in your custom checks list. Maybe you misspelt some check names?`));
+        process.exit(1);
+      } else {
+      for (var i = CHECKS.length - 1; i >= 0; i--) 
+        if (!customScan.includes(CHECKS[i].name.toLowerCase()))
+          CHECKS.splice(i, 1);
+      }
+    }
+    this._enabled_checks = CHECKS;
     this._checks_by_type = new Map();
     this.init_checks_list();
   }
@@ -20,6 +32,7 @@ export class Finder {
       const checkInstance = new check();
       this._checks_by_type.get(checkInstance.type).push(checkInstance);
     }
+    console.log(chalk.green(`${this._enabled_checks.length} checks successfully loaded.`));
   }
 
   get_sample(fileLines, index) {

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ program
   .version(VER)
   .description('Electronegativity is a tool to identify misconfigurations and security anti-patterns in Electron applications.')
   .option('-i, --input <path>', 'input [directory | .js | .html | .asar]')
+  .option('-c, --checks <checkNames>', 'only run the specified checks, passed in csv format')
   .option('-o, --output <filename[.csv | .sarif]>', 'save the results to a file in csv or sarif format')
   .parse(process.argv);
 
@@ -45,4 +46,4 @@ if(program.output){
 
 const input = path.resolve(program.input);
 
-run(input, program.output, program.fileFormat === 'sarif');
+run(input, program.output, program.fileFormat === 'sarif', program.checks);

--- a/src/runner.js
+++ b/src/runner.js
@@ -7,7 +7,7 @@ import { Parser } from './parser';
 import { Finder } from './finder';
 import { extension, input_exists, is_directory, writeIssues } from './util';
 
-export default async function run(input, output, isSarif) {
+export default async function run(input, output, isSarif, customScan) {
   if (!input_exists(input)) {
     console.log(chalk.red('Input does not exist!'));
     process.exit(1);
@@ -24,9 +24,13 @@ export default async function run(input, output, isSarif) {
 
   await loader.load(input);
 
-  // Parse
+  if (typeof customScan !== 'undefined' && customScan) {
+    customScan = customScan.split(",").map(check => check.trim().toLowerCase());
+  } else customScan = [];
+
+  // Parser
   const parser = new Parser(false, true);
-  const finder = new Finder();
+  const finder = await new Finder(customScan);
   const filenames = [...loader.list_files];
   let issues = [];
   let errors = [];
@@ -94,6 +98,10 @@ export default async function run(input, output, isSarif) {
     ]);
   }
 
-  table.push(...rows);
-  console.log(table.toString());
+  if (rows.length > 0) {
+    table.push(...rows);
+    console.log(table.toString());
+  }
+  else
+    console.log(chalk.green(`\nNo issues were found.`));
 }


### PR DESCRIPTION
Now it is possible to specify single or multiple checks names using the `-c` or `--checks` flags and passing a csv list of these (e.g. `-c PreloadJSCheck,AuxclickJSCheck`). 

Note that for the sake of convenience they are also accepted when case-insensitive and spaces between them are also allowed (i.e. `-c preloadjscheck,auxclickjscheck` and `-c "preloadjscheck, auxclickjscheck"` are both valid syntaxes). 

This pull request also adds a startup message notifying the user about the number of checks loaded.