### PR TITLE
resolves #24 adding support for on() events like 'will-navigate' and 'new-window'

### DIFF
--- a/src/finder/checks/GlobalChecks/PermissionRequestHandlerGlobalCheck.js
+++ b/src/finder/checks/GlobalChecks/PermissionRequestHandlerGlobalCheck.js
@@ -1,0 +1,20 @@
+
+export default class PermissionRequestHandlerGlobalCheck {
+
+    constructor() {
+        this.id = "PERMISSION_REQUEST_HANDLER_GLOBAL_CHECK";
+        this.description = { NONE_FOUND: "Missing setPermissionRequestHandler to limit navigation to untrusted origins."};
+        this.depends = ["PermissionRequestHandlerJSCheck"];
+    }
+
+    async perform(issues) {
+        var permissionRequestHandlerIssues = issues.filter(e => e.id === 'PERMISSION_REQUEST_HANDLER_JS_CHECK');
+        var otherIssues = issues.filter(e => e.id !== 'PERMISSION_REQUEST_HANDLER_JS_CHECK');
+
+        if (permissionRequestHandlerIssues.length === 0) {
+        	otherIssues.push({ file: "N/A", location: {line: 0, column: 0}, id: this.id, description: this.description.NONE_FOUND, manualReview: false });
+        }
+
+        return otherIssues;
+    }
+}

--- a/src/finder/checks/GlobalChecks/index.js
+++ b/src/finder/checks/GlobalChecks/index.js
@@ -1,9 +1,11 @@
 import AffinityGlobalCheck from './AffinityGlobalCheck';
 import CSPGlobalCheck from './CSPGlobalCheck';
+import PermissionRequestHandlerGlobalCheck from './PermissionRequestHandlerGlobalCheck';
 
 const GLOBAL_CHECKS = [
 	AffinityGlobalCheck,
-	CSPGlobalCheck
+	CSPGlobalCheck,
+	PermissionRequestHandlerGlobalCheck
 ];
 
 module.exports.GLOBAL_CHECKS = GLOBAL_CHECKS;

--- a/test/checks/GlobalChecks/PERMISSION_REQUEST_HANDLER_GLOBAL_CHECK_1_1/PERMISSION_REQUEST_HANDLER_CHECK_1.js
+++ b/test/checks/GlobalChecks/PERMISSION_REQUEST_HANDLER_GLOBAL_CHECK_1_1/PERMISSION_REQUEST_HANDLER_CHECK_1.js
@@ -1,0 +1,4 @@
+let win = new BrowserWindow();
+win.loadURL('https://doyensec.com');
+let ses = win.webContents.session;
+console.log(ses.getUserAgent());

--- a/test/checks/PERMISSION_REQUEST_HANDLER_JS_CHECK_2_0.js
+++ b/test/checks/PERMISSION_REQUEST_HANDLER_JS_CHECK_2_0.js
@@ -1,0 +1,4 @@
+let win = new BrowserWindow();
+win.loadURL('https://doyensec.com');
+let ses = win.webContents.session;
+console.log(ses.getUserAgent());

--- a/test/checks/PERMISSION_REQUEST_HANDLER_JS_CHECK_3_1.js
+++ b/test/checks/PERMISSION_REQUEST_HANDLER_JS_CHECK_3_1.js
@@ -1,0 +1,10 @@
+let win = new BrowserWindow();
+win.loadURL('https://doyensec.com');
+let ses = win.webContents.session;
+console.log(ses.getUserAgent());
+
+win.webContents.on('will-navigate', (event, newURL) => {
+  if (win.webContents.getURL() !== 'https://doyensec.com' ) {
+    event.preventDefault();
+  }
+})


### PR DESCRIPTION
## Description
This pull request also adds a new `PERMISSION_REQUEST_HANDLER_GLOBAL_CHECK` to check whether a `setPermissionRequestHandler` is set or not, along with its test cases.

After this pull request, Electronegativity will act as following:
### setPermissionRequestHandler
* If `setPermissionRequestHandler` is not set, `PERMISSION_REQUEST_HANDLER_GLOBAL_CHECK` will create a new issue warning of its absence (with the `manualReview` flag set to `false`).
* If `setPermissionRequestHandler` is set, `PERMISSION_REQUEST_HANDLER_JS_CHECK` will create a new issue encouraging the user to review its callback (with the `manualReview` flag set to `true`).

### on() for 'will-navigate' and 'new-window' events
* If `'will-navigate'` or `'new-window'` events are found, `PERMISSION_REQUEST_HANDLER_JS_CHECK` will create a new issue encouraging the user to review their callback (with the `manualReview` flag set to `true`).

## References
* https://electronjs.org/docs/tutorial/security#4-handle-session-permission-requests-from-remote-content