### PR TITLE
Introduce CUSTOM_ARGUMENTS_JSON_CHECK

### DIFF
--- a/src/finder/checks/CustomArgumentsJSONCheck.js
+++ b/src/finder/checks/CustomArgumentsJSONCheck.js
@@ -1,8 +1,4 @@
 import linenumber from 'linenumber';
-import fs from 'fs';
-import path from 'path';
-import os from 'os';
-import got from 'got';
 import chalk from 'chalk';
 
 import { sourceTypes } from '../../parser/types';

--- a/src/finder/checks/CustomArgumentsJSONCheck.js
+++ b/src/finder/checks/CustomArgumentsJSONCheck.js
@@ -1,0 +1,63 @@
+import linenumber from 'linenumber';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import got from 'got';
+import chalk from 'chalk';
+
+import { sourceTypes } from '../../parser/types';
+
+export default class CustomArgumentsJSONCheck {
+  constructor() {
+    this.id = 'CUSTOM_ARGUMENTS_JSON_CHECK';
+    this.description = `Search for dangerous runtime flags in the package.json file.`;
+    this.type = sourceTypes.JSON;
+    this.dangerousArguments = ["--ignore-certificate-errors", "--disable-web-security"];
+  }
+
+  async match(content){
+    const npmScripts = content.json.scripts ? content.json.scripts : undefined; //https://docs.npmjs.com/misc/scripts
+    const npmConfig = content.json.config ? content.json.config : undefined; //https://docs.npmjs.com/misc/scripts#special-packagejson-config-object
+
+    let location = [];
+
+    // We look for "scripts" key-values
+    if (npmScripts && Object.keys(npmScripts).length > 0) {
+
+      for (var script in npmScripts) {
+        if (npmScripts.hasOwnProperty(script)) {
+
+          var res = this.dangerousArguments.some(function(arg) {
+            return npmScripts[script].includes(arg);
+          });
+
+          if (res) {
+            let ln = linenumber(content.text, npmScripts[script]);
+            location.push({ line: ln[0].line, column: 0, id: this.id, description: this.description, manualReview: false });
+          }
+
+        }
+      }
+    }
+
+    // We look for "config" key-values
+    if (npmConfig && Object.keys(npmConfig).length > 0) {
+      for (var config in npmConfig) {
+        if (npmConfig.hasOwnProperty(config)) {
+
+          var res = this.dangerousArguments.some(function(arg) {
+            return npmConfig[config].includes(arg);
+          });
+
+          if (res) {
+            let ln = linenumber(content.text, npmConfig[config]);
+            location.push({ line: ln[0].line, column: 0, id: this.id, description: this.description, manualReview: false });
+          }
+
+        }
+      }
+
+    }
+    return location;
+  }
+}

--- a/src/finder/checks/GlobalChecks/PermissionRequestHandlerGlobalCheck.js
+++ b/src/finder/checks/GlobalChecks/PermissionRequestHandlerGlobalCheck.js
@@ -1,0 +1,20 @@
+
+export default class PermissionRequestHandlerGlobalCheck {
+
+    constructor() {
+        this.id = "PERMISSION_REQUEST_HANDLER_GLOBAL_CHECK";
+        this.description = { NONE_FOUND: "Missing setPermissionRequestHandler to limit navigation to untrusted origins."};
+        this.depends = ["PermissionRequestHandlerJSCheck"];
+    }
+
+    async perform(issues) {
+        var permissionRequestHandlerIssues = issues.filter(e => e.id === 'PERMISSION_REQUEST_HANDLER_JS_CHECK');
+        var otherIssues = issues.filter(e => e.id !== 'PERMISSION_REQUEST_HANDLER_JS_CHECK');
+
+        if (permissionRequestHandlerIssues.length === 0) {
+        	otherIssues.push({ file: "N/A", location: {line: 0, column: 0}, id: this.id, description: this.description.NONE_FOUND, manualReview: false });
+        }
+
+        return otherIssues;
+    }
+}

--- a/src/finder/checks/GlobalChecks/index.js
+++ b/src/finder/checks/GlobalChecks/index.js
@@ -1,9 +1,11 @@
 import AffinityGlobalCheck from './AffinityGlobalCheck';
 import CSPGlobalCheck from './CSPGlobalCheck';
+import PermissionRequestHandlerGlobalCheck from './PermissionRequestHandlerGlobalCheck';
 
 const GLOBAL_CHECKS = [
 	AffinityGlobalCheck,
-	CSPGlobalCheck
+	CSPGlobalCheck,
+	PermissionRequestHandlerGlobalCheck
 ];
 
 module.exports.GLOBAL_CHECKS = GLOBAL_CHECKS;

--- a/src/finder/checks/index.js
+++ b/src/finder/checks/index.js
@@ -11,6 +11,7 @@ import ContextIsolationJSCheck from './ContextIsolationJSCheck';
 import CSPHTMLCheck from './CSPHTMLCheck';
 import CSPJSCheck from './CSPJSCheck';
 import CustomArgumentsJSCheck from './CustomArgumentsJSCheck';
+import CustomArgumentsJSONCheck from './CustomArgumentsJSONCheck';
 import DangerousFunctionsJSCheck from './DangerousFunctionsJSCheck';
 import ElectronVersionJSONCheck from './ElectronVersionJSONCheck';
 import ExperimentalFeaturesHTMLCheck from './ExperimentalFeaturesHTMLCheck';
@@ -45,6 +46,7 @@ const CHECKS = [
   CSPHTMLCheck,
   CSPJSCheck,
   CustomArgumentsJSCheck,
+  CustomArgumentsJSONCheck,
   DangerousFunctionsJSCheck,
   ElectronVersionJSONCheck, 
   ExperimentalFeaturesJSCheck,

--- a/test/checks/CUSTOM_ARGUMENTS_JSON_CHECK_1_2.json
+++ b/test/checks/CUSTOM_ARGUMENTS_JSON_CHECK_1_2.json
@@ -1,0 +1,22 @@
+
+{
+    "name": "example_desktop_app",
+    "description": "A fake Electron app using insecure flags",
+    "main": "app/index.js",
+    "dependencies": {
+      "electron":"4.0.4",
+      "mkdirp": "^0.5.1",
+      "yauzl": "^2.5.0"
+    },
+    "scripts": {
+      "run": "node dist/index.js --disable-web-security",
+      "test": "npm run build && mocha --compilers js:babel-core/register"
+    },
+    "config": {
+    	"launchParameters" : "--ignore-certificate-errors"
+    },
+    "bin": {
+      "electronegativity": "dist/index.js"
+    }
+}
+  

--- a/test/checks/CUSTOM_ARGUMENTS_JSON_CHECK_2_0.json
+++ b/test/checks/CUSTOM_ARGUMENTS_JSON_CHECK_2_0.json
@@ -1,0 +1,22 @@
+
+{
+    "name": "example_desktop_app",
+    "description": "A fake Electron app using insecure flags",
+    "main": "app/index.js",
+    "dependencies": {
+      "electron":"4.0.4",
+      "mkdirp": "^0.5.1",
+      "yauzl": "^2.5.0"
+    },
+    "scripts": {
+      "run": "node dist/index.js",
+      "test": "npm run build && mocha --compilers js:babel-core/register"
+    },
+    "config": {
+    	"launchParameters" : "--disable-http-cache"
+    },
+    "bin": {
+      "electronegativity": "dist/index.js"
+    }
+}
+  

--- a/test/checks/GlobalChecks/PERMISSION_REQUEST_HANDLER_GLOBAL_CHECK_1_1/PERMISSION_REQUEST_HANDLER_CHECK_1.js
+++ b/test/checks/GlobalChecks/PERMISSION_REQUEST_HANDLER_GLOBAL_CHECK_1_1/PERMISSION_REQUEST_HANDLER_CHECK_1.js
@@ -1,0 +1,4 @@
+let win = new BrowserWindow();
+win.loadURL('https://doyensec.com');
+let ses = win.webContents.session;
+console.log(ses.getUserAgent());

--- a/test/checks/PERMISSION_REQUEST_HANDLER_JS_CHECK_2_0.js
+++ b/test/checks/PERMISSION_REQUEST_HANDLER_JS_CHECK_2_0.js
@@ -1,0 +1,4 @@
+let win = new BrowserWindow();
+win.loadURL('https://doyensec.com');
+let ses = win.webContents.session;
+console.log(ses.getUserAgent());

--- a/test/checks/PERMISSION_REQUEST_HANDLER_JS_CHECK_3_1.js
+++ b/test/checks/PERMISSION_REQUEST_HANDLER_JS_CHECK_3_1.js
@@ -1,0 +1,10 @@
+let win = new BrowserWindow();
+win.loadURL('https://doyensec.com');
+let ses = win.webContents.session;
+console.log(ses.getUserAgent());
+
+win.webContents.on('will-navigate', (event, newURL) => {
+  if (win.webContents.getURL() !== 'https://doyensec.com' ) {
+    event.preventDefault();
+  }
+})


### PR DESCRIPTION
## Description
This pull request introduces the `CUSTOM_ARGUMENTS_JSON_CHECK` script and its positive/negative tests.

The check will inspect the entries of the `"script"` and `"config"` objects in the `package.json` of the target application, against a `this.dangerousArguments` array of "blacklisted" flags.
Right now the blacklisted flags are only two:
* `--disable-web-security`
* `--ignore-certificate-errors`

## References
* https://electronjs.org/docs/api/chrome-command-line-switches