### PR TITLE
Introduces PERMISSION_REQUEST_HANDLER_GLOBAL_CHECK, resolves #24

### DIFF
--- a/src/finder/checks/GlobalChecks/PermissionRequestHandlerGlobalCheck.js
+++ b/src/finder/checks/GlobalChecks/PermissionRequestHandlerGlobalCheck.js
@@ -1,0 +1,21 @@
+
+export default class PermissionRequestHandlerGlobalCheck {
+
+    constructor() {
+        this.id = "PERMISSION_REQUEST_HANDLER_GLOBAL_CHECK";
+        this.description = { NONE_FOUND: "Missing PermissionRequestHandler to limit specific permissions (e.g. openExternal) in response to events from particular origins."};
+        this.depends = ["PermissionRequestHandlerJSCheck"];
+    }
+
+    async perform(issues) {
+        var permissionRequestHandlerIssues = issues.filter(e => e.id === 'PERMISSION_REQUEST_HANDLER_JS_CHECK');
+        var otherIssues = issues.filter(e => e.id !== 'PERMISSION_REQUEST_HANDLER_JS_CHECK');
+
+        if (permissionRequestHandlerIssues.length === 0) {
+        	otherIssues.push({ file: "N/A", location: {line: 0, column: 0}, id: this.id, description: this.description.NONE_FOUND, manualReview: false });
+            return otherIssues;
+        } else {
+            return issues;
+        }
+    }
+}

--- a/src/finder/checks/GlobalChecks/index.js
+++ b/src/finder/checks/GlobalChecks/index.js
@@ -1,9 +1,11 @@
 import AffinityGlobalCheck from './AffinityGlobalCheck';
 import CSPGlobalCheck from './CSPGlobalCheck';
+import PermissionRequestHandlerGlobalCheck from './PermissionRequestHandlerGlobalCheck';
 
 const GLOBAL_CHECKS = [
 	AffinityGlobalCheck,
-	CSPGlobalCheck
+	CSPGlobalCheck,
+	PermissionRequestHandlerGlobalCheck
 ];
 
 module.exports.GLOBAL_CHECKS = GLOBAL_CHECKS;

--- a/src/finder/checks/PermissionRequestHandlerJSCheck.js
+++ b/src/finder/checks/PermissionRequestHandlerJSCheck.js
@@ -7,15 +7,10 @@ export default class PermissionRequestHandlerJSCheck {
     this.type = sourceTypes.JAVASCRIPT;
   }
 
-  /*
-    Ideally, we should improve this check to detect whenever `setPermissionRequestHandler` is not used at all
-    See https://github.com/doyensec/electronegativity/issues/24
-  */
-
   match(astNode){
     if (astNode.type !== 'CallExpression') return null;
-    if (!(astNode.callee.property && astNode.callee.property.name === "setPermissionRequestHandler")) return null;
-
-    return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, manualReview: true }];
+    if (astNode.callee.property && astNode.callee.property.name === "setPermissionRequestHandler")
+      return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, manualReview: true }];
   }
+
 }

--- a/test/checks/GlobalChecks/PERMISSION_REQUEST_HANDLER_GLOBAL_CHECK_1_1/PERMISSION_REQUEST_HANDLER_GLOBAL_CHECK_1.js
+++ b/test/checks/GlobalChecks/PERMISSION_REQUEST_HANDLER_GLOBAL_CHECK_1_1/PERMISSION_REQUEST_HANDLER_GLOBAL_CHECK_1.js
@@ -1,0 +1,4 @@
+let win = new BrowserWindow();
+win.loadURL('https://doyensec.com');
+let ses = win.webContents.session;
+console.log(ses.getUserAgent()); 

--- a/test/checks/PERMISSION_REQUEST_HANDLER_JS_CHECK_2_0.js
+++ b/test/checks/PERMISSION_REQUEST_HANDLER_JS_CHECK_2_0.js
@@ -1,0 +1,4 @@
+let win = new BrowserWindow();
+win.loadURL('https://doyensec.com');
+let ses = win.webContents.session;
+console.log(ses.getUserAgent()); 


### PR DESCRIPTION
> Following @ikkisoft's review on #41, the `setPermissionRequestHandler` checks and the `on()` check for '`will-navigate`' and `'new-window`' events will be split in two different checks and consequently, two different PR.

This PR introduces the `PERMISSION_REQUEST_HANDLER_GLOBAL_CHECK`, checking for the absence of `setPermissionRequestHandler` to limit specific permissions (e.g. openExternal) in response to events from particular origins.