### PR TITLE
Introduces LIMIT_NAVIGATION_GLOBAL_CHECK and LIMIT_NAVIGATION_CHECK, resolves #24

### DIFF
--- a/src/finder/checks/GlobalChecks/LimitNavigationGlobalCheck.js
+++ b/src/finder/checks/GlobalChecks/LimitNavigationGlobalCheck.js
@@ -1,0 +1,21 @@
+
+export default class LimitNavigationGlobalCheck {
+
+    constructor() {
+        this.id = "LIMIT_NAVIGATION_GLOBAL_CHECK";
+        this.description = { NONE_FOUND: "Missing navigation limits using .on new-window and will-navigate events" };
+        this.depends = ["LimitNavigationJSCheck"];
+    }
+
+    async perform(issues) {
+        var limitNavigationIssues = issues.filter(e => e.id === 'LIMIT_NAVIGATION_CHECK');
+        var otherIssues = issues.filter(e => e.id !== 'LIMIT_NAVIGATION_CHECK');
+
+        if (limitNavigationIssues.length === 0) {
+        	otherIssues.push({ file: "N/A", location: {line: 0, column: 0}, id: this.id, description: this.description.NONE_FOUND, manualReview: false });
+            return otherIssues;
+        } else {
+            return issues;
+        }
+    }
+}

--- a/src/finder/checks/GlobalChecks/index.js
+++ b/src/finder/checks/GlobalChecks/index.js
@@ -1,9 +1,11 @@
 import AffinityGlobalCheck from './AffinityGlobalCheck';
 import CSPGlobalCheck from './CSPGlobalCheck';
+import LimitNavigationGlobalCheck from './LimitNavigationGlobalCheck';
 
 const GLOBAL_CHECKS = [
 	AffinityGlobalCheck,
-	CSPGlobalCheck
+	CSPGlobalCheck,
+	LimitNavigationGlobalCheck
 ];
 
 module.exports.GLOBAL_CHECKS = GLOBAL_CHECKS;

--- a/src/finder/checks/LimitNavigationJSCheck.js
+++ b/src/finder/checks/LimitNavigationJSCheck.js
@@ -1,0 +1,22 @@
+import { sourceTypes } from "../../parser/types";
+
+export default class LimitNavigationJSCheck {
+  constructor() {
+    this.id = 'LIMIT_NAVIGATION_CHECK';
+    this.description = 'Evaluate the implementation of the custom callback in the .on new-window and will-navigate events';
+    this.type = sourceTypes.JAVASCRIPT;
+  }
+
+  match(astNode){
+    if (astNode.type !== 'CallExpression') return null;
+    if (astNode.callee.property && astNode.callee.property.name === "on") {
+      if (astNode.arguments && astNode.arguments.length > 1) {
+        var eventValue = astNode.arguments[0].value;
+        if (astNode.arguments[0].type === "Literal" && (eventValue === "will-navigate" || eventValue === "new-window")) {
+          return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, manualReview: true }];
+        }
+      }
+    }
+  }
+
+}

--- a/src/finder/checks/index.js
+++ b/src/finder/checks/index.js
@@ -19,6 +19,7 @@ import HTTPResourcesHTMLCheck from './HTTPResourcesHTMLCheck';
 import HTTPResourcesJSCheck from './HTTPResourcesJSCheck';
 import InsecureContentHTMLCheck from './InsecureContentHTMLCheck';
 import InsecureContentJSCheck from './InsecureContentJSCheck';
+import LimitNavigationJSCheck from './LimitNavigationJSCheck';
 import NodeIntegrationHTMLCheck from './NodeIntegrationHTMLCheck';
 import NodeIntegrationJSCheck from './NodeIntegrationJSCheck';
 import NodeIntegrationAttachEventJSCheck from './NodeIntegrationAttachEventJSCheck';
@@ -53,6 +54,7 @@ const CHECKS = [
   HTTPResourcesJSCheck,
   InsecureContentHTMLCheck,
   InsecureContentJSCheck,
+  LimitNavigationJSCheck,
   NodeIntegrationHTMLCheck,
   NodeIntegrationJSCheck,
   NodeIntegrationAttachEventJSCheck,

--- a/test/checks/GlobalChecks/LIMIT_NAVIGATION_GLOBAL_CHECK_1_1/LIMIT_NAVIGATION_GLOBAL_CHECK_1.js
+++ b/test/checks/GlobalChecks/LIMIT_NAVIGATION_GLOBAL_CHECK_1_1/LIMIT_NAVIGATION_GLOBAL_CHECK_1.js
@@ -1,0 +1,6 @@
+let win = new BrowserWindow();
+win.loadURL('https://doyensec.com');
+let ses = win.webContents.session;
+console.log(ses.getUserAgent());
+
+win.webContents.on('ready', (event, newURL) => {}) 

--- a/test/checks/LIMIT_NAVIGATION_CHECK_1_1.js
+++ b/test/checks/LIMIT_NAVIGATION_CHECK_1_1.js
@@ -1,0 +1,10 @@
+let win = new BrowserWindow();
+win.loadURL('https://doyensec.com');
+let ses = win.webContents.session;
+console.log(ses.getUserAgent());
+
+win.webContents.on('will-navigate', (event, newURL) => {
+  if (win.webContents.getURL() !== 'https://doyensec.com' ) {
+    event.preventDefault();
+  }
+}) 

--- a/test/checks/LIMIT_NAVIGATION_CHECK_2_0.js
+++ b/test/checks/LIMIT_NAVIGATION_CHECK_2_0.js
@@ -1,0 +1,6 @@
+let win = new BrowserWindow();
+win.loadURL('https://doyensec.com');
+let ses = win.webContents.session;
+console.log(ses.getUserAgent());
+
+win.webContents.on('ready', (event, newURL) => {}) 


### PR DESCRIPTION
> Following @ikkisoft's review on #41, the `setPermissionRequestHandler` checks and the `on()` check for '`will-navigate`' and `'new-window`' events will be split in two different checks and consequently, two different PR.

This PR introduces the `LIMIT_NAVIGATION_CHECK` and the `LIMIT_NAVIGATION_GLOBAL_CHECK`, checking for the presence/absence of `on` to limit navigation flows.