### PR TITLE
add CUSTOM_ARGUMENTS_JSON_CHECK, improve CUSTOM_ARGUMENTS_JS_CHECK

### DIFF
--- a/src/finder/checks/CustomArgumentsJSCheck.js
+++ b/src/finder/checks/CustomArgumentsJSCheck.js
@@ -5,14 +5,56 @@ export default class CustomArgumentsJSCheck {
     this.id = 'CUSTOM_ARGUMENTS_JS_CHECK';
     this.description = `Review the use of custom command line arguments`;
     this.type = sourceTypes.JAVASCRIPT;
+    this.dangerousArguments = [
+      "ignore-certificate-errors",
+      "ignore-certificate-errors-spki-list",
+      "ignore-urlfetcher-cert-requests",
+      "disable-web-security",
+      "host-rules",
+      "host-resolver-rules",
+      "auth-server-whitelist",
+      "auth-negotiate-delegate-whitelist",
+      "js-flags",
+      "allow-file-access-from-files",
+      "allow-no-sandbox-job",
+      "allow-running-insecure-content",
+      "cipher-suite-blacklist",
+      "debug-packed-apps",
+      "disable-features",
+      "disable-kill-after-bad-ipc",
+      "disable-webrtc-encryption",
+      "disable-xss-auditor",
+      "enable-local-file-accesses",
+      "enable-nacl-debug",
+      "remote-debugging-address",
+      "remote-debugging-port",
+      "inspect",
+      "inspect-brk",
+      "explicitly-allowed-ports",
+      "expose-internals-for-testing",
+      "gpu-launcher",
+      "nacl-dangerous-no-sandbox-nonsfi",
+      "nacl-gdb-script",
+      "net-log-capture-mode",
+      "no-sandbox",
+      "reduce-security-for-testing",
+      "unsafely-treat-insecure-origin-as-secure"
+    ];
   }
 
-  match(astNode){
+  match(astNode) {
     const methods = ['appendArgument', 'appendSwitch'];
 
     if (astNode.type !== 'CallExpression') return null;
-    if (!methods.includes(astNode.callee.name) && !(astNode.callee.property && methods.includes(astNode.callee.property.name))) return null;
+    if ((astNode.callee.name && methods.includes(astNode.callee.name)) || (astNode.callee.property && methods.includes(astNode.callee.property.name))) {
+      if (astNode.arguments && astNode.arguments.length > 0 && (astNode.arguments[0].type === "Literal" || astNode.arguments[0].type === "StringLiteral") && astNode.arguments[0].value) {
+        var res = this.dangerousArguments.some(function(arg) {
+          return astNode.arguments[0].value.includes(arg);
+        });
 
-    return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, manualReview: true }];
+        if (res)
+          return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, manualReview: false }];
+      }
+    }
   }
 }

--- a/src/finder/checks/CustomArgumentsJSONCheck.js
+++ b/src/finder/checks/CustomArgumentsJSONCheck.js
@@ -1,0 +1,91 @@
+import linenumber from 'linenumber';
+
+import { sourceTypes } from '../../parser/types';
+
+export default class CustomArgumentsJSONCheck {
+  constructor() {
+    this.id = 'CUSTOM_ARGUMENTS_JSON_CHECK';
+    this.description = `Search for dangerous runtime flags in the package.json file.`;
+    this.type = sourceTypes.JSON;
+    this.dangerousArguments = [
+      "--ignore-certificate-errors",
+      "--ignore-certificate-errors-spki-list",
+      "--ignore-urlfetcher-cert-requests",
+      "--disable-web-security",
+      "--host-rules",
+      "--host-resolver-rules",
+      "--auth-server-whitelist",
+      "--auth-negotiate-delegate-whitelist",
+      "--js-flags",
+      "--allow-file-access-from-files",
+      "--allow-no-sandbox-job",
+      "--allow-running-insecure-content",
+      "--cipher-suite-blacklist",
+      "--debug-packed-apps",
+      "--disable-features",
+      "--disable-kill-after-bad-ipc",
+      "--disable-webrtc-encryption",
+      "--disable-xss-auditor",
+      "--enable-local-file-accesses",
+      "--enable-nacl-debug",
+      "--remote-debugging-address",
+      "--remote-debugging-port",
+      "--inspect",
+      "--inspect-brk",
+      "--explicitly-allowed-ports",
+      "--expose-internals-for-testing",
+      "--gpu-launcher",
+      "--nacl-dangerous-no-sandbox-nonsfi",
+      "--nacl-gdb-script",
+      "--no-sandbox",
+      "--reduce-security-for-testing",
+      "--unsafely-treat-insecure-origin-as-secure"
+    ];
+  }
+
+  async match(content){
+    const npmScripts = content.json.scripts ? content.json.scripts : undefined; //https://docs.npmjs.com/misc/scripts
+    const npmConfig = content.json.config ? content.json.config : undefined; //https://docs.npmjs.com/misc/scripts#special-packagejson-config-object
+
+    let location = [];
+
+    // We look for "scripts" key-values
+    if (npmScripts && Object.keys(npmScripts).length > 0) {
+
+      for (var script in npmScripts) {
+        if (npmScripts.hasOwnProperty(script)) {
+
+          var res = this.dangerousArguments.some(function(arg) {
+            return npmScripts[script].includes(arg);
+          });
+
+          if (res) {
+            let ln = linenumber(content.text, npmScripts[script]);
+            location.push({ line: ln[0].line, column: 0, id: this.id, description: this.description, manualReview: false });
+          }
+
+        }
+      }
+    }
+
+    // We look for "config" key-values
+    if (npmConfig && Object.keys(npmConfig).length > 0) {
+      for (var config in npmConfig) {
+        if (npmConfig.hasOwnProperty(config)) {
+
+          var res = this.dangerousArguments.some(function(arg) {
+            return npmConfig[config].includes(arg);
+          });
+
+          if (res) {
+            let ln = linenumber(content.text, npmConfig[config]);
+            location.push({ line: ln[0].line, column: 0, id: this.id, description: this.description, manualReview: false });
+          }
+
+        }
+      }
+
+    }
+    return location;
+  }
+}

--- a/src/finder/checks/index.js
+++ b/src/finder/checks/index.js
@@ -11,6 +11,7 @@ import ContextIsolationJSCheck from './ContextIsolationJSCheck';
 import CSPHTMLCheck from './CSPHTMLCheck';
 import CSPJSCheck from './CSPJSCheck';
 import CustomArgumentsJSCheck from './CustomArgumentsJSCheck';
+import CustomArgumentsJSONCheck from './CustomArgumentsJSONCheck';
 import DangerousFunctionsJSCheck from './DangerousFunctionsJSCheck';
 import ElectronVersionJSONCheck from './ElectronVersionJSONCheck';
 import ExperimentalFeaturesHTMLCheck from './ExperimentalFeaturesHTMLCheck';
@@ -45,6 +46,7 @@ const CHECKS = [
   CSPHTMLCheck,
   CSPJSCheck,
   CustomArgumentsJSCheck,
+  CustomArgumentsJSONCheck,
   DangerousFunctionsJSCheck,
   ElectronVersionJSONCheck, 
   ExperimentalFeaturesJSCheck,

--- a/test/checks/CUSTOM_ARGUMENTS_JSON_CHECK_1_2.json
+++ b/test/checks/CUSTOM_ARGUMENTS_JSON_CHECK_1_2.json
@@ -1,0 +1,21 @@
+
+{
+    "name": "example_desktop_app",
+    "description": "A fake Electron app using insecure flags",
+    "main": "app/index.js",
+    "dependencies": {
+      "electron":"4.0.4",
+      "mkdirp": "^0.5.1",
+      "yauzl": "^2.5.0"
+    },
+    "scripts": {
+      "run": "node dist/index.js --disable-web-security",
+      "test": "npm run build && mocha --compilers js:babel-core/register"
+    },
+    "config": {
+    	"launchParameters" : "--ignore-certificate-errors"
+    },
+    "bin": {
+      "electronegativity": "dist/index.js"
+    }
+}

--- a/test/checks/CUSTOM_ARGUMENTS_JSON_CHECK_2_0.json
+++ b/test/checks/CUSTOM_ARGUMENTS_JSON_CHECK_2_0.json
@@ -1,0 +1,21 @@
+
+{
+    "name": "example_desktop_app",
+    "description": "A fake Electron app using insecure flags",
+    "main": "app/index.js",
+    "dependencies": {
+      "electron":"4.0.4",
+      "mkdirp": "^0.5.1",
+      "yauzl": "^2.5.0"
+    },
+    "scripts": {
+      "run": "node dist/index.js",
+      "test": "npm run build && mocha --compilers js:babel-core/register"
+    },
+    "config": {
+    	"launchParameters" : "--disable-http-cache"
+    },
+    "bin": {
+      "electronegativity": "dist/index.js"
+    }
+}

--- a/test/checks/CUSTOM_ARGUMENTS_JS_CHECK_1_2.js
+++ b/test/checks/CUSTOM_ARGUMENTS_JS_CHECK_1_2.js
@@ -1,3 +1,3 @@
 const {app} = require('electron');
-app.commandLine.appendArgument('debug');
-app.commandLine.appendSwitch('proxy-server', '8080');
+app.commandLine.appendArgument('inspect');
+app.commandLine.appendArgument('disable-web-security');

--- a/test/checks/CUSTOM_ARGUMENTS_JS_CHECK_1_2.ts
+++ b/test/checks/CUSTOM_ARGUMENTS_JS_CHECK_1_2.ts
@@ -2,6 +2,6 @@ import { app } from "electron";
 
 export default function initialize() {
 
-  app.commandLine.appendArgument('debug');
-  app.commandLine.appendSwitch('proxy-server', '8080');
+  app.commandLine.appendArgument('inspect');
+  app.commandLine.appendSwitch('host-rules', 'MAP * 127.0.0.1');
 }

--- a/test/checks/CUSTOM_ARGUMENTS_JS_CHECK_2_0.js
+++ b/test/checks/CUSTOM_ARGUMENTS_JS_CHECK_2_0.js
@@ -1,0 +1,3 @@
+const {app} = require('electron');
+app.commandLine.appendSwitch('enable-features=GuestViewCrossProcessFrames');
+app.commandLine.appendArgument('disable-http-cache');


### PR DESCRIPTION
After @ikkisoft's review of #42, I reflected the blacklist approach of `CUSTOM_ARGUMENTS_JSON_CHECK` to `CUSTOM_ARGUMENTS_JS_CHECK`.

This pull request definitively resolves #22 and also fixes a typescript bug found on `CUSTOM_ARGUMENTS_JSON_CHECK`.

I also wrote tests and updated the wiki accordingly:
* https://github.com/doyensec/electronegativity/wiki/CUSTOM_ARGUMENTS_JS_CHECK
* https://github.com/doyensec/electronegativity/wiki/CUSTOM_ARGUMENTS_JSON_CHECK