### PR TITLE
Introduces Severity and Confidence attributes for each check

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ $ electronegativity -h
 | -V           | output the version number                         |
 | -i, --input  | input (directory, .js, .html, .asar)               |
 | -o, --output | save the results to a file in csv or sarif format |
-| -c, --checks | only run the specified checks, passed in csv format |
-| -S, --severity | only return findings with the specified level of severity or above |
-| -C, --confidence | only return findings with the specified level of confidence or above |
+| -l, --checks | only run the specified checks, passed in csv format |
+| -s, --severity | only return findings with the specified level of severity or above |
+| -c, --confidence | only return findings with the specified level of confidence or above |
 | -h, --help   | output usage information                          |
 
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ $ electronegativity -h
 | -i, --input  | input (directory, .js, .html, .asar)               |
 | -o, --output | save the results to a file in csv or sarif format |
 | -c, --checks | only run the specified checks, passed in csv format |
+| -S, --severity | only return findings with the specified level of severity or above |
+| -C, --confidence | only return findings with the specified level of confidence or above |
 | -h, --help   | output usage information                          |
 
 

--- a/src/finder/attributes.js
+++ b/src/finder/attributes.js
@@ -1,0 +1,17 @@
+import chalk from 'chalk';
+
+const severity = {
+	HIGH : { value: 3, name: "HIGH", format: () => chalk.red("HIGH") },
+	MEDIUM : { value: 2, name: "MEDIUM", format: () => chalk.keyword('orange')("MEDIUM") },
+	LOW: { value: 1, name: "LOW", format: () => chalk.yellow("LOW") },
+	INFORMATIONAL : { value: 0, name: "INFORMATIONAL", format:() => chalk.white("INFORMATIONAL") }
+};
+
+const confidence = {
+	CERTAIN : { value: 2, name: "CERTAIN", format: () => chalk.green("CERTAIN") },
+	FIRM : { value: 1, name: "FIRM", format: () => chalk.yellow("FIRM") },
+	TENTATIVE: { value: 0, name: "TENTATIVE", format: () => chalk.white("TENTATIVE") }
+};
+
+module.exports.severity = severity;
+module.exports.confidence = confidence;

--- a/src/finder/checks/AffinityHTMLCheck.js
+++ b/src/finder/checks/AffinityHTMLCheck.js
@@ -1,4 +1,5 @@
-import { sourceTypes } from "../../parser/types";
+import { sourceTypes } from '../../parser/types';
+import { severity, confidence } from '../attributes';
 import { parseWebPreferencesFeaturesString } from '../../util';
 
 export default class AffinityHTMLCheck {
@@ -17,7 +18,7 @@ export default class AffinityHTMLCheck {
       if (wp) {
         let features = parseWebPreferencesFeaturesString(wp);
         if (features['affinity'] !== undefined)
-          loc.push({ line: content.substr(0, elem.startIndex).split('\n').length, column: 0, id: self.id, description: self.description, properties: { "AffinityString": features['affinity']}, manualReview: true });
+          loc.push({ line: content.substr(0, elem.startIndex).split('\n').length, column: 0, id: self.id, description: self.description, severity: severity.MEDIUM, confidence: confidence.TENTATIVE, properties: { "AffinityString": features['affinity']}, manualReview: true });
       }
 
     });

--- a/src/finder/checks/AffinityJSCheck.js
+++ b/src/finder/checks/AffinityJSCheck.js
@@ -1,4 +1,5 @@
-import { sourceTypes } from "../../parser/types";
+import { sourceTypes } from '../../parser/types';
+import { severity, confidence } from '../attributes';
 
 export default class AffinityJSCheck {
   constructor() {
@@ -25,7 +26,7 @@ export default class AffinityJSCheck {
 
       for (const node of found_nodes) {
         if (node.value.value) {
-          location.push({ line: node.value.loc.start.line, column: node.value.loc.start.column, id: this.id, description: this.description, properties: { "AffinityString": node.value.value }, manualReview: true });
+          location.push({ line: node.value.loc.start.line, column: node.value.loc.start.column, id: this.id, description: this.description, severity: severity.MEDIUM, confidence: confidence.TENTATIVE, properties: { "AffinityString": node.value.value }, manualReview: true });
         }
       }
     }

--- a/src/finder/checks/AllowPopupHTMLCheck.js
+++ b/src/finder/checks/AllowPopupHTMLCheck.js
@@ -1,4 +1,5 @@
 import { sourceTypes } from '../../parser/types';
+import { severity, confidence } from '../attributes';
 
 export default class AllowPopupsHTMLCheck {
   constructor() {
@@ -14,7 +15,7 @@ export default class AllowPopupsHTMLCheck {
     webviews.each(function (i, elem) {
       const allowpopups = cheerioObj(this).attr('allowpopups');
       if (allowpopups !== undefined) {
-        loc.push({ line: content.substr(0, elem.startIndex).split('\n').length, column: 0, id: self.id, description: self.description, manualReview: false });
+        loc.push({ line: content.substr(0, elem.startIndex).split('\n').length, column: 0, id: self.id, description: self.description, severity: severity.LOW, confidence: confidence.CERTAIN, manualReview: false });
       }
 
     });

--- a/src/finder/checks/AuxclickHTMLCheck.js
+++ b/src/finder/checks/AuxclickHTMLCheck.js
@@ -1,4 +1,5 @@
 import { sourceTypes } from '../../parser/types';
+import { severity, confidence } from '../attributes';
 
 export default class AuxclickHTMLCheck {
   constructor() {
@@ -16,7 +17,7 @@ export default class AuxclickHTMLCheck {
       if(dbf && (dbf === "Auxclick")){
         //Nothing to report
       }else{
-        loc.push({ line: content.substr(0, elem.startIndex).split('\n').length, column: 0, id: self.id, description: self.description, manualReview: false });
+        loc.push({ line: content.substr(0, elem.startIndex).split('\n').length, column: 0, id: self.id, description: self.description, severity: severity.MEDIUM, confidence: confidence.FIRM, manualReview: false });
       }
     });
     return loc;

--- a/src/finder/checks/AuxclickJSCheck.js
+++ b/src/finder/checks/AuxclickJSCheck.js
@@ -1,4 +1,5 @@
 import { sourceTypes } from '../../parser/types';
+import { severity, confidence } from '../attributes';
 
 export default class AuxclickJSCheck {
   constructor() {
@@ -9,7 +10,7 @@ export default class AuxclickJSCheck {
 
   match(astNode, astHelper, scope) {
     if (astNode.type !== 'NewExpression') return null;
-    if (astNode.callee.name !== 'BrowserWindow') return null;
+    if (astNode.callee.name !== 'BrowserWindow' && astNode.callee.name !== 'BrowserView') return null;
 
     let location = [];
 
@@ -26,12 +27,12 @@ export default class AuxclickJSCheck {
       if (found_nodes.length > 0) {
         for (const node of found_nodes) {
           if (node.value.value.indexOf("Auxclick") == -1) {
-            location.push({ line: node.key.loc.start.line, column: node.key.loc.start.column, id: this.id, description: this.description, manualReview: false });
+            location.push({ line: node.key.loc.start.line, column: node.key.loc.start.column, id: this.id, description: this.description, severity: severity.MEDIUM, confidence: confidence.FIRM, manualReview: false });
           }
         }
       }
       else {
-        location.push({ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, manualReview: false });
+        location.push({ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, severity: severity.MEDIUM, confidence: confidence.FIRM, manualReview: false });
       }
       
     }

--- a/src/finder/checks/BlinkFeaturesHTMLCheck.js
+++ b/src/finder/checks/BlinkFeaturesHTMLCheck.js
@@ -1,4 +1,5 @@
 import { sourceTypes } from '../../parser/types';
+import { severity, confidence } from '../attributes';
 
 export default class BlinkFeaturesHTMLCheck {
   constructor() {
@@ -14,7 +15,7 @@ export default class BlinkFeaturesHTMLCheck {
     webviews.each(function (i, elem) {
       let wp = cheerioObj(this).attr('enableblinkfeatures');
       if(wp){
-        loc.push({ line: content.substr(0, elem.startIndex).split('\n').length, column: 0, id: self.id, description: self.description, manualReview: true });
+        loc.push({ line: content.substr(0, elem.startIndex).split('\n').length, column: 0, id: self.id, description: self.description, severity: severity.LOW, confidence: confidence.CERTAIN, manualReview: true });
       }
 
       // search for both names for now
@@ -22,7 +23,7 @@ export default class BlinkFeaturesHTMLCheck {
       // https://github.com/electron/electron/blob/master/docs/api/breaking-changes.md#browserwindow
       wp = cheerioObj(this).attr('blinkfeatures');
       if(wp){
-        loc.push({ line: content.substr(0, elem.startIndex).split('\n').length, column: 0, id: self.id, description: self.description, manualReview: true });
+        loc.push({ line: content.substr(0, elem.startIndex).split('\n').length, column: 0, id: self.id, description: self.description, severity: severity.LOW, confidence: confidence.CERTAIN, manualReview: true });
       }
     });
     return loc;

--- a/src/finder/checks/BlinkFeaturesJSCheck.js
+++ b/src/finder/checks/BlinkFeaturesJSCheck.js
@@ -1,4 +1,5 @@
 import { sourceTypes } from '../../parser/types';
+import { severity, confidence } from '../attributes';
 
 export default class BlinkFeaturesJSCheck {
   constructor() {
@@ -9,7 +10,7 @@ export default class BlinkFeaturesJSCheck {
 
   match(astNode, astHelper, scope){
     if (astNode.type !== 'NewExpression') return null;
-    if (astNode.callee.name !== 'BrowserWindow') return null;
+    if (astNode.callee.name !== 'BrowserWindow' && astNode.callee.name !== 'BrowserView') return null;
 
     let location = [];
 
@@ -28,7 +29,7 @@ export default class BlinkFeaturesJSCheck {
                  node.key.value === 'blinkFeatures' || node.key.name === 'blinkFeatures'));
 
       for (const node of found_nodes) {
-        location.push({ line: node.key.loc.start.line, column: node.key.loc.start.column, id: this.id, description: this.description, manualReview: true });
+        location.push({ line: node.key.loc.start.line, column: node.key.loc.start.column, id: this.id, description: this.description, severity: severity.LOW, confidence: confidence.CERTAIN, manualReview: true });
       }
     }
 

--- a/src/finder/checks/CSPHTMLCheck.js
+++ b/src/finder/checks/CSPHTMLCheck.js
@@ -1,4 +1,5 @@
 import { sourceTypes } from '../../parser/types';
+import { severity, confidence } from '../attributes';
 
 export default class CSPHTMLCheck {
   constructor() {
@@ -15,7 +16,7 @@ export default class CSPHTMLCheck {
       const httpEquiv = cheerioObj(this).attr('http-equiv');
       const cspContent = cheerioObj(this).attr('content');
       if (httpEquiv && httpEquiv.toLowerCase() === "Content-Security-Policy".toLowerCase()) {
-        loc.push({ line: content.substr(0, elem.startIndex).split('\n').length, column: 0, id: self.id, description: self.description, properties: { "CSPstring": cspContent }, manualReview: true });
+        loc.push({ line: content.substr(0, elem.startIndex).split('\n').length, column: 0, id: self.id, description: self.description, severity: severity.INFORMATIONAL, confidence: confidence.TENTATIVE, properties: { "CSPstring": cspContent }, manualReview: true });
       }
     });
     return loc;

--- a/src/finder/checks/CSPJSCheck.js
+++ b/src/finder/checks/CSPJSCheck.js
@@ -1,4 +1,5 @@
 import { sourceTypes } from '../../parser/types';
+import { severity, confidence } from '../attributes';
 
 export default class CSPJSCheck {
   constructor() {
@@ -11,7 +12,7 @@ export default class CSPJSCheck {
     let location = [];
     // match e.g. details.responseHeaders["content-security-policy"] = "default-src 'self'"; Note that this does not check if the assignment is inside in the responseHeaders object because of #32
     if (astNode.type === "AssignmentExpression" && astNode.left.property && astNode.left.property.value && astNode.left.property.value.toString().toLowerCase() === "content-security-policy")
-      location.push({ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, properties: { "CSPstring": astNode.right.value }, manualReview: true });
+      location.push({ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description,severity: severity.INFORMATIONAL, confidence: confidence.TENTATIVE, properties: { "CSPstring": astNode.right.value }, manualReview: true });
     else if (astNode.type == "CallExpression") {
       if (astNode.arguments.length > 0) {
         if (astNode.arguments[0].type !== "ObjectExpression") return null;
@@ -26,16 +27,16 @@ export default class CSPJSCheck {
           if (node.value.properties) {
             for (const property of node.value.properties)
               if (property.key && property.key.value && property.key.value.toLowerCase() === "content-security-policy")
-                location.push({ line: node.key.loc.start.line, column: node.key.loc.start.column, id: this.id, description: this.description, properties: { "CSPstring": property.value.elements[0].value }, manualReview: true });
+                location.push({ line: node.key.loc.start.line, column: node.key.loc.start.column, id: this.id, description: this.description,severity: severity.INFORMATIONAL, confidence: confidence.TENTATIVE, properties: { "CSPstring": property.value.elements[0].value }, manualReview: true });
           } // match callback({ responseHeaders: Object.assign({"Content-Security-Policy": [ "default-src 'self'" ]}, details.responseHeaders)}); as a popular stackoverflow answer suggests https://stackoverflow.com/questions/51969512/define-csp-http-header-in-electron-app
           else if (node.value.type === 'CallExpression') {
-              if (node.value.arguments.length > 0) {
-                for (const argument of node.value.arguments)
-                  if (argument.type === 'ObjectExpression')
-                    for (const property of argument.properties)
-                      if (property.key && property.key.value === 'Content-Security-Policy')
-                        location.push({ line: node.value.loc.start.line, column: node.value.loc.start.column, id: this.id, description: this.description, properties: { "CSPstring": property.value.elements[0].value}, manualReview: true });  
-              }
+            if (node.value.arguments.length > 0) {
+              for (const argument of node.value.arguments)
+                if (argument.type === 'ObjectExpression')
+                  for (const property of argument.properties)
+                    if (property.key && property.key.value === 'Content-Security-Policy')
+                      location.push({ line: node.value.loc.start.line, column: node.value.loc.start.column, id: this.id, description: this.description,severity: severity.INFORMATIONAL, confidence: confidence.TENTATIVE, properties: { "CSPstring": property.value.elements[0].value}, manualReview: true });  
+            }
           }
         }
       }

--- a/src/finder/checks/CertificateErrorEventJSCheck.js
+++ b/src/finder/checks/CertificateErrorEventJSCheck.js
@@ -1,4 +1,5 @@
 import { sourceTypes } from '../../parser/types';
+import { severity, confidence } from '../attributes';
 
 export default class CertificateErrorEventJSCheck {
   constructor() {
@@ -16,6 +17,6 @@ export default class CertificateErrorEventJSCheck {
       return null;
     }
 
-    return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, manualReview: true }];
+    return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, severity: severity.MEDIUM, confidence: confidence.TENTATIVE, manualReview: true }];
   }
 }

--- a/src/finder/checks/CertificateVerifyProcJSCheck.js
+++ b/src/finder/checks/CertificateVerifyProcJSCheck.js
@@ -1,4 +1,5 @@
 import { sourceTypes } from '../../parser/types';
+import { severity, confidence } from '../attributes';
 
 export default class CertificateVerifyProcJSCheck {
   constructor() {
@@ -13,12 +14,12 @@ export default class CertificateVerifyProcJSCheck {
 
     if (astNode.callee.property && astNode.callee.property.name === "setCertificateVerifyProc") {
       const description = 'Verify that the application does not explicitly opt-out from TLS validation';
-      return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: description, manualReview: true }];
+      return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: description, severity: severity.MEDIUM, confidence: confidence.TENTATIVE, manualReview: true }];
     }
 
     if (astNode.callee.property && astNode.callee.property.name === "importCertificate") {
       const description = 'Verify custom TLS certificates imported into the platform certificate store';
-      return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: description, manualReview: true }];
+      return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: description, severity: severity.MEDIUM, confidence: confidence.TENTATIVE, manualReview: true }];
     }
   }
 }

--- a/src/finder/checks/ContextIsolationJSCheck.js
+++ b/src/finder/checks/ContextIsolationJSCheck.js
@@ -1,4 +1,5 @@
 import { sourceTypes } from '../../parser/types';
+import { severity, confidence } from '../attributes';
 
 export default class ContextIsolationJSCheck {
   constructor() {
@@ -9,7 +10,7 @@ export default class ContextIsolationJSCheck {
 
   match(astNode, astHelper, scope){
     if (astNode.type !== 'NewExpression') return null;
-    if (astNode.callee.name !== 'BrowserWindow') return null;
+    if (astNode.callee.name !== 'BrowserWindow' && astNode.callee.name !== 'BrowserView') return null;
 
     let location = [];
     if (astNode.arguments.length > 0) {
@@ -36,16 +37,16 @@ export default class ContextIsolationJSCheck {
           // but technically it is an invalid json
           // just to be on the safe side show a warning if any value is insecure
           if(node.value.value !== true) {
-            location.push({ line: node.key.loc.start.line, column: node.key.loc.start.column, id: this.id, description: this.description, manualReview: false });
+            location.push({ line: node.key.loc.start.line, column: node.key.loc.start.column, id: this.id, description: this.description, severity: severity.HIGH, confidence: confidence.FIRM, manualReview: false });
           }
         }
       } else {
-        location.push({ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, manualReview: false });
+        location.push({ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, severity: severity.HIGH, confidence: confidence.FIRM, manualReview: false });
       }
       
     } else {
       //No webpreferences
-      location.push({ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, manualReview: false });
+      location.push({ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, severity: severity.HIGH, confidence: confidence.FIRM, manualReview: false });
     }
 
     return location;

--- a/src/finder/checks/CustomArgumentsJSCheck.js
+++ b/src/finder/checks/CustomArgumentsJSCheck.js
@@ -1,4 +1,5 @@
 import { sourceTypes } from '../../parser/types';
+import { severity, confidence } from '../attributes';
 
 export default class CustomArgumentsJSCheck {
   constructor() {
@@ -53,7 +54,7 @@ export default class CustomArgumentsJSCheck {
         });
 
         if (res)
-          return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, manualReview: false }];
+          return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, severity: severity.MEDIUM, confidence: confidence.TENTATIVE, manualReview: false }];
       }
     }
   }

--- a/src/finder/checks/CustomArgumentsJSONCheck.js
+++ b/src/finder/checks/CustomArgumentsJSONCheck.js
@@ -1,6 +1,7 @@
 import linenumber from 'linenumber';
 
 import { sourceTypes } from '../../parser/types';
+import { severity, confidence } from '../attributes';
 
 export default class CustomArgumentsJSONCheck {
   constructor() {
@@ -61,7 +62,7 @@ export default class CustomArgumentsJSONCheck {
 
           if (res) {
             let ln = linenumber(content.text, npmScripts[script]);
-            location.push({ line: ln[0].line, column: 0, id: this.id, description: this.description, manualReview: false });
+            location.push({ line: ln[0].line, column: 0, id: this.id, description: this.description, severity: severity.MEDIUM, confidence: confidence.TENTATIVE, manualReview: false });
           }
 
         }
@@ -79,7 +80,7 @@ export default class CustomArgumentsJSONCheck {
 
           if (res) {
             let ln = linenumber(content.text, npmConfig[config]);
-            location.push({ line: ln[0].line, column: 0, id: this.id, description: this.description, manualReview: false });
+            location.push({ line: ln[0].line, column: 0, id: this.id, description: this.description, severity: severity.MEDIUM, confidence: confidence.TENTATIVE, manualReview: false });
           }
 
         }

--- a/src/finder/checks/DangerousFunctionsJSCheck.js
+++ b/src/finder/checks/DangerousFunctionsJSCheck.js
@@ -1,4 +1,5 @@
 import { sourceTypes } from '../../parser/types';
+import { severity, confidence } from '../attributes';
 
 export default class DangerousFunctionsJSCheck {
   constructor() {
@@ -18,6 +19,6 @@ export default class DangerousFunctionsJSCheck {
     if (!methods.includes(astNode.callee.name) && !(astNode.callee.property && methods.includes(astNode.callee.property.name))) return null;
     if (astNode.arguments[0].type === astHelper.StringLiteral) return null; // constant, not user supplied
 
-    return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, manualReview: true }];
+    return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, severity: severity.MEDIUM, confidence: confidence.CERTAIN, manualReview: true }];
   }
 }

--- a/src/finder/checks/ElectronVersionJSONCheck.js
+++ b/src/finder/checks/ElectronVersionJSONCheck.js
@@ -7,6 +7,7 @@ import got from 'got';
 import chalk from 'chalk';
 
 import { sourceTypes } from '../../parser/types';
+import { severity, confidence } from '../attributes';
 
 let releases;
 
@@ -53,7 +54,7 @@ export default class ElectronVersionJSONCheck {
       let matches = linenumber(data.text, /(?:"electron"|electron)\s*:\s*.*[,}]?/g);
       for (const m of matches) {
         if (m.match.includes(version.raw))
-          location.push({ line: m.line, column: 0, id: this.id, description: this.description, manualReview: false });
+          location.push({ line: m.line, column: 0, id: this.id, description: this.description, severity: severity.HIGH, confidence: confidence.TENTATIVE, manualReview: false });
       }
     }
   }

--- a/src/finder/checks/ExperimentalFeaturesHTMLCheck.js
+++ b/src/finder/checks/ExperimentalFeaturesHTMLCheck.js
@@ -1,4 +1,5 @@
-import { sourceTypes } from "../../parser/types";
+import { sourceTypes } from '../../parser/types';
+import { severity, confidence } from '../attributes';
 import { parseWebPreferencesFeaturesString } from '../../util';
 
 export default class ExperimentalFeaturesHTMLCheck {
@@ -17,7 +18,7 @@ export default class ExperimentalFeaturesHTMLCheck {
       if (wp) {
         let features = parseWebPreferencesFeaturesString(wp);
         if (features['experimentalFeatures'] === true || features['experimentalCanvasFeatures'] === true)
-          loc.push({ line: content.substr(0, elem.startIndex).split('\n').length, column: 0, id: self.id, description: self.description, manualReview: false });
+          loc.push({ line: content.substr(0, elem.startIndex).split('\n').length, column: 0, id: self.id, description: self.description, severity: severity.LOW, confidence: confidence.CERTAIN, manualReview: false });
       }
 
     });

--- a/src/finder/checks/ExperimentalFeaturesJSCheck.js
+++ b/src/finder/checks/ExperimentalFeaturesJSCheck.js
@@ -1,4 +1,5 @@
 import { sourceTypes } from '../../parser/types';
+import { severity, confidence } from '../attributes';
 
 export default class ExperimentalFeaturesJSCheck {
   constructor() {
@@ -9,7 +10,7 @@ export default class ExperimentalFeaturesJSCheck {
 
   match(astNode, astHelper, scope){
     if (astNode.type !== 'NewExpression') return null;
-    if (astNode.callee.name !== 'BrowserWindow') return null;
+    if (astNode.callee.name !== 'BrowserWindow' && astNode.callee.name !== 'BrowserView') return null;
 
     let location = [];
 
@@ -28,7 +29,7 @@ export default class ExperimentalFeaturesJSCheck {
 
       for (const node of found_nodes) {
         if (node.value.value === true) {
-          location.push({ line: node.key.loc.start.line, column: node.key.loc.start.column, id: this.id, description: this.description, manualReview: false });
+          location.push({ line: node.key.loc.start.line, column: node.key.loc.start.column, id: this.id, description: this.description, severity: severity.LOW, confidence: confidence.CERTAIN, manualReview: false });
         }
       }
     }

--- a/src/finder/checks/GlobalChecks/CSPGlobalCheck.js
+++ b/src/finder/checks/GlobalChecks/CSPGlobalCheck.js
@@ -1,43 +1,44 @@
-import * as csp from '@doyensec/csp-evaluator'
+import * as attributes from '../../attributes';
+import * as csp from '@doyensec/csp-evaluator';
 
 export default class CSPGlobalCheck {
 
-    constructor() {
-        this.id = "CSP_GLOBAL_CHECK";
-        this.description = {  NO_CSP: "No CSP has been detected in the target application",
-                              MAYBE_WEAK_CSP: "One or more CSP directives detected seems to be vulnerable",
-                              WEAK_CSP: "One or more CSP directives detected are vulnerable" };
-        this.depends = ["CSPJSCheck", "CSPHTMLCheck"];
+  constructor() {
+    this.id = "CSP_GLOBAL_CHECK";
+    this.description = {  NO_CSP: "No CSP has been detected in the target application",
+      MAYBE_WEAK_CSP: "One or more CSP directives detected seems to be vulnerable",
+      WEAK_CSP: "One or more CSP directives detected are vulnerable" };
+    this.depends = ["CSPJSCheck", "CSPHTMLCheck"];
+  }
+
+  async perform(issues) {
+    var cspIssues = issues.filter(e => e.id === 'CSP_JS_CHECK' || e.id === 'CSP_HTML_CHECK');
+    var otherIssues = issues.filter(e => e.id !== 'CSP_JS_CHECK' && e.id !== 'CSP_HTML_CHECK');
+    if (cspIssues.length === 0) {
+      // No CSP detected
+      issues.push({ file: "N/A", location: {line: 0, column: 0}, id: this.id, description: this.description.NO_CSP, severity: attributes.severity.HIGH, confidence: attributes.confidence.CERTAIN, manualReview: false });
+      return issues;
+    } else {
+      // There is a CSP set
+      var confidence = 0; 
+      for (var cspIssue of cspIssues) {
+        var parser = new csp.CspParser(cspIssue.properties.CSPstring);
+        var evaluator = new csp.CspEvaluator(parser.csp, csp.Version.CSP3);
+        var findings = evaluator.evaluate();
+        for (var finding of findings)
+          if (finding.severity === csp.severities.HIGH || finding.severity === csp.severities.MEDIUM)
+            confidence = 2;
+          else if (finding.severity === csp.severities.HIGH_MAYBE || finding.severity === csp.severities.MEDIUM_MAYBE)
+            if (confidence < 2) confidence = 1;
+      }
+
+      if (confidence === 2) 
+        otherIssues.push({ file: cspIssues[0].file, location: cspIssues[0].location, id: this.id, description: this.description.WEAK_CSP, severity: attributes.severity.MEDIUM, confidence: attributes.confidence.CERTAIN, manualReview: false });
+      if (confidence === 1)
+        otherIssues.push({ file: cspIssues[0].file, location: cspIssues[0].location, id: this.id, description: this.description.MAYBE_WEAK_CSP, severity: attributes.severity.MEDIUM, confidence: attributes.confidence.FIRM, manualReview: true });
+
+
+      return otherIssues;
     }
-
-    async perform(issues) {
-        var cspIssues = issues.filter(e => e.id === 'CSP_JS_CHECK' || e.id === 'CSP_HTML_CHECK');
-        var otherIssues = issues.filter(e => e.id !== 'CSP_JS_CHECK' && e.id !== 'CSP_HTML_CHECK');
-        if (cspIssues.length === 0) {
-            // No CSP detected
-            issues.push({ file: "N/A", location: {line: 0, column: 0}, id: this.id, description: this.description.NO_CSP, manualReview: false });
-            return issues;
-        } else {
-            // There is a CSP set
-            var confidence = 0; 
-            for (var cspIssue of cspIssues) {
-                var parser = new csp.CspParser(cspIssue.properties.CSPstring);
-                var evaluator = new csp.CspEvaluator(parser.csp, csp.Version.CSP3);
-                var findings = evaluator.evaluate();
-                for (var finding of findings)
-                    if (finding.severity === csp.severities.HIGH || finding.severity === csp.severities.MEDIUM)
-                        confidence = 2;
-                    else if (finding.severity === csp.severities.HIGH_MAYBE || finding.severity === csp.severities.MEDIUM_MAYBE)
-                        if (confidence < 2) confidence = 1;
-            }
-
-            if (confidence === 2) 
-                otherIssues.push({ file: cspIssues[0].file, location: cspIssues[0].location, id: this.id, description: this.description.WEAK_CSP, manualReview: false });
-            if (confidence === 1)
-                otherIssues.push({ file: cspIssues[0].file, location: cspIssues[0].location, id: this.id, description: this.description.MAYBE_WEAK_CSP, manualReview: true });
-
-
-            return otherIssues;
-        }
-    }
+  }
 }

--- a/src/finder/checks/GlobalChecks/CSPGlobalCheck.js
+++ b/src/finder/checks/GlobalChecks/CSPGlobalCheck.js
@@ -16,7 +16,7 @@ export default class CSPGlobalCheck {
     var otherIssues = issues.filter(e => e.id !== 'CSP_JS_CHECK' && e.id !== 'CSP_HTML_CHECK');
     if (cspIssues.length === 0) {
       // No CSP detected
-      issues.push({ file: "N/A", location: {line: 0, column: 0}, id: this.id, description: this.description.NO_CSP, severity: attributes.severity.HIGH, confidence: attributes.confidence.CERTAIN, manualReview: false });
+      issues.push({ file: "N/A", location: {line: 0, column: 0}, id: this.id, description: this.description.NO_CSP, severity: attributes.severity.MEDIUM, confidence: attributes.confidence.CERTAIN, manualReview: false });
       return issues;
     } else {
       // There is a CSP set
@@ -33,9 +33,9 @@ export default class CSPGlobalCheck {
       }
 
       if (confidence === 2) 
-        otherIssues.push({ file: cspIssues[0].file, location: cspIssues[0].location, id: this.id, description: this.description.WEAK_CSP, severity: attributes.severity.MEDIUM, confidence: attributes.confidence.CERTAIN, manualReview: false });
+        otherIssues.push({ file: cspIssues[0].file, location: cspIssues[0].location, id: this.id, description: this.description.WEAK_CSP, severity: attributes.severity.LOW, confidence: attributes.confidence.CERTAIN, manualReview: false });
       if (confidence === 1)
-        otherIssues.push({ file: cspIssues[0].file, location: cspIssues[0].location, id: this.id, description: this.description.MAYBE_WEAK_CSP, severity: attributes.severity.MEDIUM, confidence: attributes.confidence.FIRM, manualReview: true });
+        otherIssues.push({ file: cspIssues[0].file, location: cspIssues[0].location, id: this.id, description: this.description.MAYBE_WEAK_CSP, severity: attributes.severity.LOW, confidence: attributes.confidence.FIRM, manualReview: true });
 
 
       return otherIssues;

--- a/src/finder/checks/GlobalChecks/LimitNavigationGlobalCheck.js
+++ b/src/finder/checks/GlobalChecks/LimitNavigationGlobalCheck.js
@@ -13,7 +13,7 @@ export default class LimitNavigationGlobalCheck {
     var otherIssues = issues.filter(e => e.id !== 'LIMIT_NAVIGATION_JS_CHECK');
 
     if (limitNavigationIssues.length === 0) {
-      otherIssues.push({ file: "N/A", location: {line: 0, column: 0}, id: this.id, description: this.description.NONE_FOUND,severity: severity.MEDIUM, confidence: confidence.CERTAIN, manualReview: false });
+      otherIssues.push({ file: "N/A", location: {line: 0, column: 0}, id: this.id, description: this.description.NONE_FOUND,severity: severity.HIGH, confidence: confidence.CERTAIN, manualReview: false });
       return otherIssues;
     } else {
       return issues;

--- a/src/finder/checks/GlobalChecks/LimitNavigationGlobalCheck.js
+++ b/src/finder/checks/GlobalChecks/LimitNavigationGlobalCheck.js
@@ -1,21 +1,22 @@
+import { severity, confidence } from '../../attributes';
 
 export default class LimitNavigationGlobalCheck {
 
-    constructor() {
-        this.id = "LIMIT_NAVIGATION_GLOBAL_CHECK";
-        this.description = { NONE_FOUND: "Missing navigation limits using .on new-window and will-navigate events" };
-        this.depends = ["LimitNavigationJSCheck"];
-    }
+  constructor() {
+    this.id = "LIMIT_NAVIGATION_GLOBAL_CHECK";
+    this.description = { NONE_FOUND: "Missing navigation limits using .on new-window and will-navigate events" };
+    this.depends = ["LimitNavigationJSCheck"];
+  }
 
-    async perform(issues) {
-        var limitNavigationIssues = issues.filter(e => e.id === 'LIMIT_NAVIGATION_JS_CHECK');
-        var otherIssues = issues.filter(e => e.id !== 'LIMIT_NAVIGATION_JS_CHECK');
+  async perform(issues) {
+    var limitNavigationIssues = issues.filter(e => e.id === 'LIMIT_NAVIGATION_JS_CHECK');
+    var otherIssues = issues.filter(e => e.id !== 'LIMIT_NAVIGATION_JS_CHECK');
 
-        if (limitNavigationIssues.length === 0) {
-        	otherIssues.push({ file: "N/A", location: {line: 0, column: 0}, id: this.id, description: this.description.NONE_FOUND, manualReview: false });
-            return otherIssues;
-        } else {
-            return issues;
-        }
+    if (limitNavigationIssues.length === 0) {
+      otherIssues.push({ file: "N/A", location: {line: 0, column: 0}, id: this.id, description: this.description.NONE_FOUND,severity: severity.MEDIUM, confidence: confidence.CERTAIN, manualReview: false });
+      return otherIssues;
+    } else {
+      return issues;
     }
+  }
 }

--- a/src/finder/checks/GlobalChecks/PermissionRequestHandlerGlobalCheck.js
+++ b/src/finder/checks/GlobalChecks/PermissionRequestHandlerGlobalCheck.js
@@ -1,21 +1,22 @@
+import { severity, confidence } from '../../attributes';
 
 export default class PermissionRequestHandlerGlobalCheck {
 
-    constructor() {
-        this.id = "PERMISSION_REQUEST_HANDLER_GLOBAL_CHECK";
-        this.description = { NONE_FOUND: "Missing PermissionRequestHandler to limit specific permissions (e.g. openExternal) in response to events from particular origins."};
-        this.depends = ["PermissionRequestHandlerJSCheck"];
-    }
+  constructor() {
+    this.id = "PERMISSION_REQUEST_HANDLER_GLOBAL_CHECK";
+    this.description = { NONE_FOUND: "Missing PermissionRequestHandler to limit specific permissions (e.g. openExternal) in response to events from particular origins."};
+    this.depends = ["PermissionRequestHandlerJSCheck"];
+  }
 
-    async perform(issues) {
-        var permissionRequestHandlerIssues = issues.filter(e => e.id === 'PERMISSION_REQUEST_HANDLER_JS_CHECK');
-        var otherIssues = issues.filter(e => e.id !== 'PERMISSION_REQUEST_HANDLER_JS_CHECK');
+  async perform(issues) {
+    var permissionRequestHandlerIssues = issues.filter(e => e.id === 'PERMISSION_REQUEST_HANDLER_JS_CHECK');
+    var otherIssues = issues.filter(e => e.id !== 'PERMISSION_REQUEST_HANDLER_JS_CHECK');
 
-        if (permissionRequestHandlerIssues.length === 0) {
-        	otherIssues.push({ file: "N/A", location: {line: 0, column: 0}, id: this.id, description: this.description.NONE_FOUND, manualReview: false });
-            return otherIssues;
-        } else {
-            return issues;
-        }
+    if (permissionRequestHandlerIssues.length === 0) {
+      otherIssues.push({ file: "N/A", location: {line: 0, column: 0}, id: this.id, description: this.description.NONE_FOUND,severity: severity.MEDIUM, confidence: confidence.CERTAIN, manualReview: false });
+      return otherIssues;
+    } else {
+      return issues;
     }
+  }
 }

--- a/src/finder/checks/GlobalChecks/index.js
+++ b/src/finder/checks/GlobalChecks/index.js
@@ -7,7 +7,7 @@ const GLOBAL_CHECKS = [
   AffinityGlobalCheck,
   CSPGlobalCheck,
   LimitNavigationGlobalCheck,
-	PermissionRequestHandlerGlobalCheck
+  PermissionRequestHandlerGlobalCheck
 ];
 
 module.exports.GLOBAL_CHECKS = GLOBAL_CHECKS;

--- a/src/finder/checks/HTTPResourcesHTMLCheck.js
+++ b/src/finder/checks/HTTPResourcesHTMLCheck.js
@@ -1,4 +1,5 @@
-import { sourceTypes } from "../../parser/types";
+import { sourceTypes } from '../../parser/types';
+import { severity, confidence } from '../attributes';
 
 export default class HTTPResourcesHTMLCheck {
   constructor() {
@@ -14,7 +15,7 @@ export default class HTTPResourcesHTMLCheck {
     webviews.each(function (i, elem) {
       let src = cheerioObj(this).attr('src');
       if(src && (src.trim().toUpperCase().startsWith("HTTP://"))){
-        loc.push({ line: content.substr(0, elem.startIndex).split('\n').length, column: 0, id: self.id, description: self.description, manualReview: false });
+        loc.push({ line: content.substr(0, elem.startIndex).split('\n').length, column: 0, id: self.id, description: self.description, severity: severity.MEDIUM, confidence: confidence.CERTAIN, manualReview: false });
       }
 
     });

--- a/src/finder/checks/HTTPResourcesJSCheck.js
+++ b/src/finder/checks/HTTPResourcesJSCheck.js
@@ -1,4 +1,5 @@
-import { sourceTypes } from "../../parser/types";
+import { sourceTypes } from '../../parser/types';
+import { severity, confidence } from '../attributes';
 
 export default class HTTPResourcesJavascriptCheck {
   constructor() {
@@ -26,6 +27,6 @@ export default class HTTPResourcesJavascriptCheck {
         return undefined;
     }
 
-    return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, manualReview: false }];
+    return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, severity: severity.MEDIUM, confidence: confidence.CERTAIN, manualReview: false }];
   }
 }

--- a/src/finder/checks/InsecureContentHTMLCheck.js
+++ b/src/finder/checks/InsecureContentHTMLCheck.js
@@ -1,4 +1,5 @@
-import { sourceTypes } from "../../parser/types";
+import { sourceTypes } from '../../parser/types';
+import { severity, confidence } from '../attributes';
 import { parseWebPreferencesFeaturesString } from '../../util';
 
 export default class InsecureContentHTMLCheck {
@@ -17,7 +18,7 @@ export default class InsecureContentHTMLCheck {
       if (wp) {
         let features = parseWebPreferencesFeaturesString(wp);
         if (features['allowRunningInsecureContent'] === true)
-          loc.push({ line: content.substr(0, elem.startIndex).split('\n').length, column: 0, id: self.id, description: self.description, manualReview: false });
+          loc.push({ line: content.substr(0, elem.startIndex).split('\n').length, column: 0, id: self.id, description: self.description, severity: severity.MEDIUM, confidence: confidence.CERTAIN, manualReview: false });
       }
 
     });

--- a/src/finder/checks/InsecureContentJSCheck.js
+++ b/src/finder/checks/InsecureContentJSCheck.js
@@ -1,4 +1,5 @@
-import { sourceTypes } from "../../parser/types";
+import { sourceTypes } from '../../parser/types';
+import { severity, confidence } from '../attributes';
 
 export default class InsecureContentJSCheck {
   constructor() {
@@ -9,7 +10,7 @@ export default class InsecureContentJSCheck {
 
   match(astNode, astHelper, scope){
     if (astNode.type !== 'NewExpression') return null;
-    if (astNode.callee.name !== 'BrowserWindow') return null;
+    if (astNode.callee.name !== 'BrowserWindow' && astNode.callee.name !== 'BrowserView') return null;
 
     let location = [];
 
@@ -25,7 +26,7 @@ export default class InsecureContentJSCheck {
 
       for (const node of found_nodes) {
         if (node.value.value === true) {
-          location.push({ line: node.key.loc.start.line, column: node.key.loc.start.column, id: this.id, description: this.description, manualReview: false });
+          location.push({ line: node.key.loc.start.line, column: node.key.loc.start.column, id: this.id, description: this.description, severity: severity.MEDIUM, confidence: confidence.CERTAIN, manualReview: false });
         }
       }
     }

--- a/src/finder/checks/LimitNavigationJSCheck.js
+++ b/src/finder/checks/LimitNavigationJSCheck.js
@@ -1,4 +1,5 @@
-import { sourceTypes } from "../../parser/types";
+import { sourceTypes } from '../../parser/types';
+import { severity, confidence } from '../attributes';
 
 export default class LimitNavigationJSCheck {
   constructor() {
@@ -13,7 +14,7 @@ export default class LimitNavigationJSCheck {
       if (astNode.arguments && astNode.arguments.length > 1) {
         var eventValue = astNode.arguments[0].value;
         if (astNode.arguments[0].type === "Literal" && (eventValue === "will-navigate" || eventValue === "new-window")) {
-          return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, manualReview: true }];
+          return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, severity: severity.MEDIUM, confidence: confidence.TENTATIVE, manualReview: true }];
         }
       }
     }

--- a/src/finder/checks/LimitNavigationJSCheck.js
+++ b/src/finder/checks/LimitNavigationJSCheck.js
@@ -14,7 +14,7 @@ export default class LimitNavigationJSCheck {
       if (astNode.arguments && astNode.arguments.length > 1) {
         var eventValue = astNode.arguments[0].value;
         if (astNode.arguments[0].type === "Literal" && (eventValue === "will-navigate" || eventValue === "new-window")) {
-          return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, severity: severity.MEDIUM, confidence: confidence.TENTATIVE, manualReview: true }];
+          return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, severity: severity.HIGH, confidence: confidence.TENTATIVE, manualReview: true }];
         }
       }
     }

--- a/src/finder/checks/NodeIntegrationAttachEventJSCheck.js
+++ b/src/finder/checks/NodeIntegrationAttachEventJSCheck.js
@@ -1,4 +1,5 @@
-import { sourceTypes } from "../../parser/types";
+import { sourceTypes } from '../../parser/types';
+import { severity, confidence } from '../attributes';
 
 export default class NodeIntegrationAttachEventJSCheck {
   constructor() {
@@ -24,7 +25,7 @@ export default class NodeIntegrationAttachEventJSCheck {
                 && node.left.property.name === 'nodeIntegration'
                 && node.right.value === true);
       if (found_nodes.length > 0) {
-        loc.push({ line: found_nodes[0].loc.start.line, column: found_nodes[0].loc.start.column, id: this.id, description: this.description, manualReview: false });
+        loc.push({ line: found_nodes[0].loc.start.line, column: found_nodes[0].loc.start.column, id: this.id, description: this.description, severity: severity.HIGH, confidence: confidence.FIRM, manualReview: false });
       }
     }
 

--- a/src/finder/checks/NodeIntegrationHTMLCheck.js
+++ b/src/finder/checks/NodeIntegrationHTMLCheck.js
@@ -1,4 +1,5 @@
-import { sourceTypes } from "../../parser/types";
+import { sourceTypes } from '../../parser/types';
+import { severity, confidence } from '../attributes';
 
 export default class NodeIntegrationHTMLCheck {
   constructor() {
@@ -14,7 +15,7 @@ export default class NodeIntegrationHTMLCheck {
     webviews.each(function (i, elem) {
       const nodeintegration = cheerioObj(this).attr('nodeintegration');
       if (nodeintegration !== undefined) {
-        loc.push({ line: content.substr(0, elem.startIndex).split('\n').length, column: 0, id: self.id, description: self.description, manualReview: false });
+        loc.push({ line: content.substr(0, elem.startIndex).split('\n').length, column: 0, id: self.id, description: self.description, severity: severity.HIGH, confidence: confidence.FIRM, manualReview: false });
       }
     });
     return loc;

--- a/src/finder/checks/NodeIntegrationJSCheck.js
+++ b/src/finder/checks/NodeIntegrationJSCheck.js
@@ -1,4 +1,5 @@
-import { sourceTypes } from "../../parser/types";
+import { sourceTypes } from '../../parser/types';
+import { severity, confidence } from '../attributes';
 
 export default class NodeIntegrationJSCheck {
   constructor() {
@@ -12,7 +13,7 @@ export default class NodeIntegrationJSCheck {
 
   match(astNode, astHelper, scope){
     if (astNode.type !== 'NewExpression') return null;
-    if (astNode.callee.name !== 'BrowserWindow') return null;
+    if (astNode.callee.name !== 'BrowserWindow' && astNode.callee.name !== 'BrowserView') return null;
 
     let nodeIntegrationFound = false;
     let locations = [];
@@ -34,7 +35,7 @@ export default class NodeIntegrationJSCheck {
     }
 
     if (!nodeIntegrationFound) {
-      locations.push({ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, manualReview: false });
+      locations.push({ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, severity: severity.HIGH, confidence: confidence.FIRM, manualReview: false });
     }
 
     return locations;

--- a/src/finder/checks/OpenExternalJSCheck.js
+++ b/src/finder/checks/OpenExternalJSCheck.js
@@ -1,4 +1,5 @@
-import { sourceTypes } from "../../parser/types";
+import { sourceTypes } from '../../parser/types';
+import { severity, confidence } from '../attributes';
 
 export default class OpenExternalJSCheck {
   constructor() {
@@ -12,6 +13,6 @@ export default class OpenExternalJSCheck {
     if (!(astNode.callee.property && astNode.callee.property.name === "openExternal")) return null;
     if (astNode.arguments[0].type === astHelper.StringLiteral) return null; // constant, not user supplied
 
-    return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, manualReview: true }];
+    return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, severity: severity.MEDIUM, confidence: confidence.TENTATIVE, manualReview: true }];
   }
 }

--- a/src/finder/checks/PermissionRequestHandlerJSCheck.js
+++ b/src/finder/checks/PermissionRequestHandlerJSCheck.js
@@ -1,4 +1,5 @@
-import { sourceTypes } from "../../parser/types";
+import { sourceTypes } from '../../parser/types';
+import { severity, confidence } from '../attributes';
 
 export default class PermissionRequestHandlerJSCheck {
   constructor() {
@@ -10,7 +11,7 @@ export default class PermissionRequestHandlerJSCheck {
   match(astNode){
     if (astNode.type !== 'CallExpression') return null;
     if (astNode.callee.property && astNode.callee.property.name === "setPermissionRequestHandler")
-      return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, manualReview: true }];
+      return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, severity: severity.MEDIUM, confidence: confidence.TENTATIVE, manualReview: true }];
   }
 
 }

--- a/src/finder/checks/PreloadJSCheck.js
+++ b/src/finder/checks/PreloadJSCheck.js
@@ -1,4 +1,5 @@
-import { sourceTypes } from "../../parser/types";
+import { sourceTypes } from '../../parser/types';
+import { severity, confidence } from '../attributes';
 
 export default class PreloadJSCheck {
   constructor() {
@@ -9,7 +10,7 @@ export default class PreloadJSCheck {
 
   match(astNode, astHelper, scope){
     if (astNode.type !== 'NewExpression') return null;
-    if (astNode.callee.name !== 'BrowserWindow') return null;
+    if (astNode.callee.name !== 'BrowserWindow' && astNode.callee.name !== 'BrowserView') return null;
 
     let location = [];
 
@@ -24,7 +25,7 @@ export default class PreloadJSCheck {
         node => (node.key.value === 'preload' || node.key.name === 'preload'));
 
       for (const node of found_nodes)
-        location.push ({ line: node.key.loc.start.line, column: node.key.loc.start.column, id: this.id, description: this.description, manualReview: true });
+        location.push ({ line: node.key.loc.start.line, column: node.key.loc.start.column, id: this.id, description: this.description, severity: severity.MEDIUM, confidence: confidence.FIRM, manualReview: true });
     }
 
     return location;

--- a/src/finder/checks/ProtocolHandlersJSCheck.js
+++ b/src/finder/checks/ProtocolHandlersJSCheck.js
@@ -1,4 +1,5 @@
-import { sourceTypes } from "../../parser/types";
+import { sourceTypes } from '../../parser/types';
+import { severity, confidence } from '../attributes';
 
 export default class ProtocolHandlerJSCheck {
   constructor() {
@@ -21,6 +22,6 @@ export default class ProtocolHandlerJSCheck {
     if (astNode.type !== 'CallExpression') return null;
     if (!methods.includes(astNode.callee.name) && !(astNode.callee.property && methods.includes(astNode.callee.property.name))) return null;
 
-    return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, manualReview: true }];
+    return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, severity: severity.MEDIUM, confidence: confidence.TENTATIVE, manualReview: true }];
   }
 }

--- a/src/finder/checks/SandboxJSCheck.js
+++ b/src/finder/checks/SandboxJSCheck.js
@@ -1,4 +1,5 @@
-import { sourceTypes } from "../../parser/types";
+import { sourceTypes } from '../../parser/types';
+import { severity, confidence } from '../attributes';
 
 export default class SandboxJSCheck {
   constructor() {
@@ -9,7 +10,7 @@ export default class SandboxJSCheck {
 
   match(astNode, astHelper, scope){
     if (astNode.type !== 'NewExpression') return null;
-    if (astNode.callee.name !== 'BrowserWindow') return null;
+    if (astNode.callee.name !== 'BrowserWindow' && astNode.callee.name !== 'BrowserView') return null;
 
     let wasFound = false;
     let loc = [];
@@ -28,14 +29,14 @@ export default class SandboxJSCheck {
         if (node.value.value === true) {
           continue;
         }
-        loc.push({ line: node.key.loc.start.line, column: node.key.loc.start.column, id: this.id, description: this.description, manualReview: false });
+        loc.push({ line: node.key.loc.start.line, column: node.key.loc.start.column, id: this.id, description: this.description, severity: severity.MEDIUM, confidence: confidence.FIRM, manualReview: false });
       }
     }
 
     if (wasFound) {
       return loc;
     } else { // default is false
-      return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, manualReview: false }];
+      return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, severity: severity.MEDIUM, confidence: confidence.FIRM, manualReview: false }];
     }
   }
 }

--- a/src/finder/checks/WebSecurityHTMLCheck.js
+++ b/src/finder/checks/WebSecurityHTMLCheck.js
@@ -1,4 +1,5 @@
-import { sourceTypes } from "../../parser/types";
+import { sourceTypes } from '../../parser/types';
+import { severity, confidence } from '../attributes';
 import { parseWebPreferencesFeaturesString } from '../../util';
 
 export default class WebSecurityHTMLCheck {
@@ -22,7 +23,7 @@ export default class WebSecurityHTMLCheck {
       if (wp) {
         let features = parseWebPreferencesFeaturesString(wp);
         if (features['webSecurity'] === false)
-          loc.push({ line: content.substr(0, elem.startIndex).split('\n').length, column: 0, id: self.id, description: self.description, manualReview: false });
+          loc.push({ line: content.substr(0, elem.startIndex).split('\n').length, column: 0, id: self.id, description: self.description, severity: severity.MEDIUM, confidence: confidence.CERTAIN, manualReview: false });
       }
 
     });

--- a/src/finder/checks/WebSecurityJSCheck.js
+++ b/src/finder/checks/WebSecurityJSCheck.js
@@ -1,4 +1,5 @@
-import { sourceTypes } from "../../parser/types";
+import { sourceTypes } from '../../parser/types';
+import { severity, confidence } from '../attributes';
 
 export default class WebSecurityJSCheck {
   constructor() {
@@ -9,7 +10,7 @@ export default class WebSecurityJSCheck {
 
   match(astNode, astHelper, scope){
     if (astNode.type !== 'NewExpression') return null;
-    if (astNode.callee.name !== 'BrowserWindow') return null;
+    if (astNode.callee.name !== 'BrowserWindow' && astNode.callee.name !== 'BrowserView') return null;
 
     let location = [];
 
@@ -25,7 +26,7 @@ export default class WebSecurityJSCheck {
 
       for (const node of found_nodes) {
         if (node.value.value === false) {
-          location.push({ line: node.key.loc.start.line, column: node.key.loc.start.column, id: this.id, description: this.description, manualReview: false });
+          location.push({ line: node.key.loc.start.line, column: node.key.loc.start.column, id: this.id, description: this.description, severity: severity.MEDIUM, confidence: confidence.CERTAIN, manualReview: false });
         }
       }
     }

--- a/src/finder/finder.js
+++ b/src/finder/finder.js
@@ -64,7 +64,7 @@ export class Finder {
               if (matches) {
                 for(const m of matches) {
                   const sample = this.get_sample(fileLines, m.line - 1);
-                  const issue = { file, sample, location: {line: m.line, column: m.column}, id: m.id, description: m.description, properties: m.properties, manualReview: m.manualReview };
+                  const issue = { file, sample, location: {line: m.line, column: m.column}, id: m.id, description: m.description, properties: m.properties, severity: m.severity, confidence: m.confidence, manualReview: m.manualReview };
                   issues.push(issue);
                 }
               }
@@ -82,7 +82,7 @@ export class Finder {
           if(matches){
             for(const m of matches) {
               const sample = this.get_sample(fileLines, m.line - 1);
-              const issue = {file, sample, location: {line: m.line, column: m.column}, id: m.id, description: m.description, properties: m.properties, manualReview: m.manualReview};
+              const issue = {file, sample, location: {line: m.line, column: m.column}, id: m.id, description: m.description, properties: m.properties, severity: m.severity, confidence: m.confidence, manualReview: m.manualReview};
               issues.push(issue);
             }
           }
@@ -94,7 +94,7 @@ export class Finder {
           if (matches) {
             for(const m of matches) {
               const sample = this.get_sample(fileLines, m.line - 1);
-              const issue = {file, sample, location: {line: m.line, column: m.column}, id: m.id, description: m.description, properties: m.properties, manualReview: m.manualReview};
+              const issue = {file, sample, location: {line: m.line, column: m.column}, id: m.id, description: m.description, properties: m.properties, severity: m.severity, confidence: m.confidence, manualReview: m.manualReview};
               issues.push(issue);
             }
           }

--- a/src/finder/index.js
+++ b/src/finder/index.js
@@ -1,5 +1,8 @@
 import { Finder } from './finder';
 import { GlobalChecks } from './globalchecks';
+import { severity, confidence } from './attributes';
 
 module.exports.Finder = Finder;
 module.exports.GlobalChecks = GlobalChecks;
+module.exports.severity = severity;
+module.exports.confidence = confidence;

--- a/src/index.js
+++ b/src/index.js
@@ -26,9 +26,9 @@ program
   .version(VER)
   .description('Electronegativity is a tool to identify misconfigurations and security anti-patterns in Electron applications.')
   .option('-i, --input <path>', 'input [directory | .js | .html | .asar]')
-  .option('-c, --checks <checkNames>', 'only run the specified checks, passed in csv format')
-  .option('-S, --severity <severitySet>', 'only return findings above the passed level of severity')
-  .option('-C, --confidence <confidenceSet>', 'only return findings above the passed level of confidence')
+  .option('-c, --checks <checkNames>', 'only run the specified checks list, passed in csv format')
+  .option('-S, --severity <severitySet>', 'only return findings with the specified level of severity or above')
+  .option('-C, --confidence <confidenceSet>', 'only return findings with the specified level of confidence or above')
   .option('-o, --output <filename[.csv | .sarif]>', 'save the results to a file in csv or sarif format')
   .parse(process.argv);
 

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,8 @@ program
   .description('Electronegativity is a tool to identify misconfigurations and security anti-patterns in Electron applications.')
   .option('-i, --input <path>', 'input [directory | .js | .html | .asar]')
   .option('-c, --checks <checkNames>', 'only run the specified checks, passed in csv format')
+  .option('-S, --severity <severitySet>', 'only return findings above the passed level of severity')
+  .option('-C, --confidence <confidenceSet>', 'only return findings above the passed level of confidence')
   .option('-o, --output <filename[.csv | .sarif]>', 'save the results to a file in csv or sarif format')
   .parse(process.argv);
 
@@ -44,6 +46,10 @@ if(program.output){
   }
 }
 
+if (typeof program.checks !== 'undefined' && program.checks){
+    program.checks = program.checks.split(",").map(check => check.trim().toLowerCase());
+} else program.checks = [];
+
 const input = path.resolve(program.input);
 
-run(input, program.output, program.fileFormat === 'sarif', program.checks);
+run(input, program.output, program.fileFormat === 'sarif', program.checks, program.severity, program.confidence);

--- a/src/index.js
+++ b/src/index.js
@@ -26,9 +26,9 @@ program
   .version(VER)
   .description('Electronegativity is a tool to identify misconfigurations and security anti-patterns in Electron applications.')
   .option('-i, --input <path>', 'input [directory | .js | .html | .asar]')
-  .option('-c, --checks <checkNames>', 'only run the specified checks list, passed in csv format')
-  .option('-S, --severity <severitySet>', 'only return findings with the specified level of severity or above')
-  .option('-C, --confidence <confidenceSet>', 'only return findings with the specified level of confidence or above')
+  .option('-l, --checks <checkNames>', 'only run the specified checks list, passed in csv format')
+  .option('-s, --severity <severitySet>', 'only return findings with the specified level of severity or above')
+  .option('-c, --confidence <confidenceSet>', 'only return findings with the specified level of confidence or above')
   .option('-o, --output <filename[.csv | .sarif]>', 'save the results to a file in csv or sarif format')
   .parse(process.argv);
 

--- a/src/runner.js
+++ b/src/runner.js
@@ -8,7 +8,7 @@ import { Finder } from './finder';
 import { GlobalChecks, severity, confidence } from './finder';
 import { extension, input_exists, is_directory, writeIssues } from './util';
 
-export default async function run(input, output, isSarif, customScan) {
+export default async function run(input, output, isSarif, customScan, severitySet, confidenceSet) {
   if (!input_exists(input)) {
     console.log(chalk.red('Input does not exist!'));
     process.exit(1);
@@ -25,9 +25,19 @@ export default async function run(input, output, isSarif, customScan) {
 
   await loader.load(input);
 
-  if (typeof customScan !== 'undefined' && customScan) {
-    customScan = customScan.split(",").map(check => check.trim().toLowerCase());
-  } else customScan = [];
+  if (severitySet) {
+    if (!severity.hasOwnProperty(severitySet.toUpperCase())) {
+      console.log(chalk.red('This severity level does not exist!'));
+      process.exit(1);
+    } else severitySet = severity[severitySet.toUpperCase()];
+  } else severitySet = severity["INFORMATIONAL"]; // default to lowest
+
+  if (confidenceSet) {
+    if (!confidence.hasOwnProperty(confidenceSet.toUpperCase())) {
+      console.log(chalk.red('This confidence level does not exist!'));
+      process.exit(1);
+    } else confidenceSet = confidence[confidenceSet.toUpperCase()];
+  } else confidenceSet = confidence["TENTATIVE"]; // default to lowest
 
   // Parser
   const parser = new Parser(false, true);
@@ -100,12 +110,13 @@ export default async function run(input, output, isSarif, customScan) {
 
   let rows = [];
   for (const issue of issues) {
-    rows.push([
-      `${issue.id}${issue.manualReview ? chalk.bgRed(`\n*Review Required*`) : ``}\n${issue.severity.format()} | ${issue.confidence.format()}`,
-      issue.file,
-      `${issue.location.line}:${issue.location.column}`,
-      `https://github.com/doyensec/electronegativity/wiki/${issue.id}`
-    ]);
+    if (issue.severity.value >= severitySet.value && issue.confidence.value >= confidenceSet.value)
+      rows.push([
+        `${issue.id}${issue.manualReview ? chalk.bgRed(`\n*Review Required*`) : ``}\n${issue.severity.format()} | ${issue.confidence.format()}`,
+        issue.file,
+        `${issue.location.line}:${issue.location.column}`,
+        `https://github.com/doyensec/electronegativity/wiki/${issue.id}`
+      ]);
   }
 
   if (rows.length > 0) {

--- a/src/runner.js
+++ b/src/runner.js
@@ -5,7 +5,7 @@ import chalk from 'chalk';
 import { LoaderFile, LoaderAsar, LoaderDirectory } from './loader';
 import { Parser } from './parser';
 import { Finder } from './finder';
-import { GlobalChecks } from './finder';
+import { GlobalChecks, severity, confidence } from './finder';
 import { extension, input_exists, is_directory, writeIssues } from './util';
 
 export default async function run(input, output, isSarif, customScan) {
@@ -101,7 +101,7 @@ export default async function run(input, output, isSarif, customScan) {
   let rows = [];
   for (const issue of issues) {
     rows.push([
-      `${issue.id} ${issue.manualReview ? chalk.bgRed(`\n*Review Required*`) : ``}`,
+      `${issue.id}${issue.manualReview ? chalk.bgRed(`\n*Review Required*`) : ``}\n${issue.severity.format()} | ${issue.confidence.format()}`,
       issue.file,
       `${issue.location.line}:${issue.location.column}`,
       `https://github.com/doyensec/electronegativity/wiki/${issue.id}`

--- a/test/checks/AUXCLICK_JS_CHECK_8_1.js
+++ b/test/checks/AUXCLICK_JS_CHECK_8_1.js
@@ -1,0 +1,1 @@
+mainWindow = new BrowserView({ "webPreferences": {}});

--- a/test/checks/AUXCLICK_JS_CHECK_8_1.js
+++ b/test/checks/AUXCLICK_JS_CHECK_8_1.js
@@ -1,1 +1,0 @@
-mainWindow = new BrowserView({ "webPreferences": {}});

--- a/test/checks/AUXCLICK_JS_CHECK_8_2.js
+++ b/test/checks/AUXCLICK_JS_CHECK_8_2.js
@@ -1,0 +1,13 @@
+
+// In the main process.
+const { BrowserView, BrowserWindow } = require('electron')
+
+let win = new BrowserWindow({ width: 800, height: 600 })
+win.on('closed', () => {
+  win = null
+})
+
+let view = new BrowserView({ "webPreferences": {}});
+win.setBrowserView(view)
+view.setBounds({ x: 0, y: 0, width: 300, height: 300 })
+view.webContents.loadURL('https://electronjs.org')

--- a/test/checks/BLINK_FEATURES_JS_CHECK_6_1.js
+++ b/test/checks/BLINK_FEATURES_JS_CHECK_6_1.js
@@ -1,11 +1,23 @@
 function start() {
-    let config = {
-      webPreferences: {
-        enableBlinkFeatures: "blinkFeatures"
-      }
+  let config = {
+    webPreferences: {
+      enableBlinkFeatures: "blinkFeatures"
     }
+  };
+  
+  // In the main process.
+  const { BrowserView, BrowserWindow } = require('electron')
 
-    mainWindow = new BrowserView(config);
+  let win = new BrowserWindow({ width: 800, height: 600 })
+  win.on('closed', () => {
+    win = null
+  })
+
+  let view = new BrowserView(config);
+  win.setBrowserView(view)
+  view.setBounds({ x: 0, y: 0, width: 300, height: 300 })
+  view.webContents.loadURL('https://electronjs.org')
 }
+
 
 start();

--- a/test/checks/BLINK_FEATURES_JS_CHECK_6_1.js
+++ b/test/checks/BLINK_FEATURES_JS_CHECK_6_1.js
@@ -1,0 +1,11 @@
+function start() {
+    let config = {
+      webPreferences: {
+        enableBlinkFeatures: "blinkFeatures"
+      }
+    }
+
+    mainWindow = new BrowserView(config);
+}
+
+start();

--- a/test/checks/CONTEXT_ISOLATION_JS_CHECK_6_1.js
+++ b/test/checks/CONTEXT_ISOLATION_JS_CHECK_6_1.js
@@ -1,0 +1,7 @@
+let test_preferences = {
+  webPreferences: {
+    contextIsolation: false,
+  }
+};
+
+mainWindow = new BrowserView(test_preferences);

--- a/test/checks/CONTEXT_ISOLATION_JS_CHECK_6_1.js
+++ b/test/checks/CONTEXT_ISOLATION_JS_CHECK_6_1.js
@@ -1,7 +1,0 @@
-let test_preferences = {
-  webPreferences: {
-    contextIsolation: false,
-  }
-};
-
-mainWindow = new BrowserView(test_preferences);

--- a/test/checks/CONTEXT_ISOLATION_JS_CHECK_6_2.js
+++ b/test/checks/CONTEXT_ISOLATION_JS_CHECK_6_2.js
@@ -1,0 +1,19 @@
+// In the main process.
+const { BrowserView, BrowserWindow } = require('electron')
+
+let test_preferences = {
+  webPreferences: {
+    contextIsolation: false,
+  }
+};
+
+let win = new BrowserWindow({ width: 800, height: 600 })
+win.on('closed', () => {
+  win = null
+})
+
+let view = new BrowserView(test_preferences);
+
+win.setBrowserView(view)
+view.setBounds({ x: 0, y: 0, width: 300, height: 300 })
+view.webContents.loadURL('https://electronjs.org')

--- a/test/checks/EXPERIMENTAL_FEATURES_JS_CHECK_6_2.js
+++ b/test/checks/EXPERIMENTAL_FEATURES_JS_CHECK_6_2.js
@@ -1,0 +1,11 @@
+mainWindow = new BrowserView({
+  "webPreferences": {
+    experimentalCanvasFeatures: true
+  }
+});
+
+mainWindow = new BrowserView({
+  "webPreferences": {
+    experimentalFeatures: true
+  }
+});

--- a/test/checks/EXPERIMENTAL_FEATURES_JS_CHECK_6_2.js
+++ b/test/checks/EXPERIMENTAL_FEATURES_JS_CHECK_6_2.js
@@ -1,11 +1,30 @@
-mainWindow = new BrowserView({
+// In the main process.
+const { BrowserView, BrowserWindow } = require('electron')
+
+let firstWin = new BrowserWindow({ width: 800, height: 600 })
+let secondWin = new BrowserWindow({ width: 800, height: 600 })
+
+firstWin.on('closed', () => {
+  firstWin = null
+})
+
+let firstViewConfig = new BrowserView({
   "webPreferences": {
     experimentalCanvasFeatures: true
   }
-});
+})
 
-mainWindow = new BrowserView({
+let secondViewConfig = new BrowserView({
   "webPreferences": {
-    experimentalFeatures: true
+    experimentalCanvasFeatures: true
   }
-});
+})
+
+firstWin.setBrowserView(firstWin)
+secondWin.setBrowserView(secondWin)
+
+firstWin.setBounds({ x: 0, y: 0, width: 300, height: 300 })
+firstWin.webContents.loadURL('https://electronjs.org')
+
+secondWin.setBounds({ x: 0, y: 0, width: 300, height: 300 })
+secondWin.webContents.loadURL('https://doyensec.com')

--- a/test/checks/PRELOAD_JS_CHECK_6_1.js
+++ b/test/checks/PRELOAD_JS_CHECK_6_1.js
@@ -1,0 +1,11 @@
+var config = {
+  "webPreferences": {
+    "preload": 'preload.js'
+  }
+};
+
+function start() {
+  mainWindow = new BrowserView(config);
+}
+
+start();

--- a/test/checks/SANDBOX_JS_CHECK_12_1.js
+++ b/test/checks/SANDBOX_JS_CHECK_12_1.js
@@ -1,3 +1,0 @@
-mainWindow = new BrowserView({ "webPreferences": {
-  sandbox: false }
-});

--- a/test/checks/SANDBOX_JS_CHECK_12_1.js
+++ b/test/checks/SANDBOX_JS_CHECK_12_1.js
@@ -1,0 +1,3 @@
+mainWindow = new BrowserView({ "webPreferences": {
+  sandbox: false }
+});

--- a/test/checks/SANDBOX_JS_CHECK_12_2.js
+++ b/test/checks/SANDBOX_JS_CHECK_12_2.js
@@ -1,14 +1,11 @@
 // In the main process.
 const { BrowserView, BrowserWindow } = require('electron')
 
-var config = {
-  "webPreferences": {
-    "preload": 'preload.js'
-  }
+var config = { "webPreferences": {
+  sandbox: false }
 };
 
 function start() {
-  mainWindow = new BrowserView(config);
   let win = new BrowserWindow({ width: 800, height: 600 })
   win.on('closed', () => {
     win = null

--- a/test/checks/WEB_SECURITY_JS_CHECK_8_1.js
+++ b/test/checks/WEB_SECURITY_JS_CHECK_8_1.js
@@ -1,5 +1,28 @@
-const mainWindow = new BrowserView({
+// In the main process.
+const { BrowserView, BrowserWindow } = require('electron')
+
+var config = {
   webPreferences: {
     webSecurity: false
   }
-})
+};
+
+function start() {
+  mainWindow = new BrowserView(config);
+  let win = new BrowserWindow({ width: 800, height: 600 })
+  win.on('closed', () => {
+    win = null
+  })
+
+  let view = new BrowserView({
+    webPreferences: {
+      nodeIntegration: false
+    }
+  });
+
+  win.setBrowserView(config)
+  view.setBounds({ x: 0, y: 0, width: 300, height: 300 })
+  view.webContents.loadURL('https://electronjs.org')
+}
+
+start();

--- a/test/checks/WEB_SECURITY_JS_CHECK_8_1.js
+++ b/test/checks/WEB_SECURITY_JS_CHECK_8_1.js
@@ -1,0 +1,5 @@
+const mainWindow = new BrowserView({
+  webPreferences: {
+    webSecurity: false
+  }
+})


### PR DESCRIPTION
This PR will introduce Severity and Confidence attributes for each check, closing #31.

The proposed **Severity** levels are:
* HIGH
* MEDIUM
* LOW
* INFORMATIONAL

The proposed **Confidence** levels are:
* CERTAIN
* FIRM
* TENTATIVE

The following table summarizes the changes. The "VARY" flag indicates that the severity/confidence of the finding is set by a Global Check or that it may take into account other parameters and change the severity/confidence accordingly.

### Atomic checks
Check Name | Severity Set | Confidence Set | 
-- | -- | -- |
[AffinityHTMLCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/AffinityHTMLCheck.js) | VARY | VARY
[AffinityJSCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/AffinityJSCheck.js) | VARY | VARY
[AllowPopupHTMLCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/AllowPopupHTMLCheck.js) | LOW | CERTAIN
[AuxclickHTMLCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/AuxclickHTMLCheck.js) | MEDIUM | FIRM
[AuxclickJSCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/AuxclickJSCheck.js) | MEDIUM | FIRM
[BlinkFeaturesHTMLCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/BlinkFeaturesHTMLCheck.js) | LOW | CERTAIN
[BlinkFeaturesJSCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/BlinkFeaturesJSCheck.js) | LOW | CERTAIN
[CertificateErrorEventJSCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/CertificateErrorEventJSCheck.js) | MEDIUM | TENTATIVE
[CertificateVerifyProcJSCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/CertificateVerifyProcJSCheck.js) | MEDIUM | TENTATIVE
[ContextIsolationJSCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/ContextIsolationJSCheck.js) | HIGH | FIRM
[CSPHTMLCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/CSPHTMLCheck.js) | VARY | VARY
[CSPJSCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/CSPJSCheck.js) | VARY | VARY
[CustomArgumentsJSCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/CustomArgumentsJSCheck.js) | MEDIUM | TENTATIVE
[DangerousFunctionsJSCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/DangerousFunctionsJSCheck.js) | MEDIUM | CERTAIN
[ElectronVersionJSONCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/ElectronVersionJSONCheck.js) | HIGH | TENTATIVE
[ExperimentalFeaturesHTMLCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/ExperimentalFeaturesHTMLCheck.js) | LOW | CERTAIN
[ExperimentalFeaturesJSCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/ExperimentalFeaturesJSCheck.js) | LOW | CERTAIN
[HTTPResourcesHTMLCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/HTTPResourcesHTMLCheck.js) | MEDIUM | CERTAIN
[HTTPResourcesJSCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/HTTPResourcesJSCheck.js) | MEDIUM | CERTAIN
[InsecureContentHTMLCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/InsecureContentHTMLCheck.js) | MEDIUM | CERTAIN
[InsecureContentJSCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/InsecureContentJSCheck.js) | MEDIUM | CERTAIN
[LimitNavigationJSCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/LimitNavigationJSCheck.js) | MEDIUM | TENTATIVE
[NodeIntegrationAttachEventJSCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/NodeIntegrationAttachEventJSCheck.js) | HIGH | FIRM
[NodeIntegrationHTMLCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/NodeIntegrationHTMLCheck.js) | HIGH | FIRM
[NodeIntegrationJSCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/NodeIntegrationJSCheck.js) | HIGH | FIRM
[OpenExternalJSCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/OpenExternalJSCheck.js) | MEDIUM | TENTATIVE
[PermissionRequestHandlerJSCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/PermissionRequestHandlerJSCheck.js) | MEDIUM | TENTATIVE
[PreloadJSCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/PreloadJSCheck.js) | MEDIUM | FIRM
[ProtocolHandlersJSCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/ProtocolHandlersJSCheck.js) | MEDIUM | TENTATIVE
[SandboxJSCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/SandboxJSCheck.js) | MEDIUM | FIRM
[WebSecurityHTMLCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/WebSecurityHTMLCheck.js) | MEDIUM | CERTAIN
[WebSecurityJSCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/WebSecurityJSCheck.js) | MEDIUM | CERTAIN

### Global checks
Check Name | Severity Set | Confidence Set | Notes
-- | -- | -- | -- |
[AffinityGlobalCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/GlobalChecks/AffinityGlobalCheck.js) | MEDIUM | CERTAIN
[CSPGlobalCheck.js.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/GlobalChecks/CSPGlobalCheck.js.js) | VARY | VARY | Set according to [@doyensec/csp-evaluator](https://www.npmjs.com/package/@doyensec/csp-evaluator) sev/conf
[LimitNavigationGlobalCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/GlobalChecks/LimitNavigationGlobalCheck.js) | MEDIUM | CERTAIN
[PermissionRequestHandlerGlobalCheck.js](https://github.com/phosphore/electronegativity/blob/9c8056b196591754760571b3eeda6f1adfbdf46e/src/finder/checks/GlobalChecks/PermissionRequestHandlerGlobalCheck.js) | MEDIUM | CERTAIN

Since to do this I had to edit each check, I also added support for `BrowserView` in checks already looking for `BrowserWindow`, consequently closing #25. This PR also add new tests for the aforementioned check supporting `BrowserView`.