### PR TITLE
New Remote Module Not Disabled Check

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,11 @@ If you're thinking about contributing to this project, please take a look at our
 
 ## Credits
 
-Electronegativity was made possible thanks to the work of [Claudio Merloni](https://github.com/p4p3r), [Ibram Marzouk](https://github.com/0xibram), [Jaroslav Lobačevski](https://github.com/JarLob) and many other [contributors](https://github.com/doyensec/electronegativity/graphs/contributors).
+Electronegativity was made possible thanks to the work of many [contributors](https://github.com/doyensec/electronegativity/graphs/contributors).
 
-This work has been sponsored by [Doyensec LLC](https://www.doyensec.com).
+This project has been sponsored by [Doyensec LLC](https://www.doyensec.com). 
 
 ![alt text](https://doyensec.com/images/logo.svg "Doyensec Logo")
+
+[Engage us to break](https://doyensec.com/auditing.html) your Electron.js application!
 

--- a/src/finder/checks/AtomicChecks/RemoteModuleJSCheck.js
+++ b/src/finder/checks/AtomicChecks/RemoteModuleJSCheck.js
@@ -1,0 +1,43 @@
+import { sourceTypes } from '../../../parser/types';
+import { severity, confidence } from '../../attributes';
+
+export default class RemoteModuleJSCheck {
+  constructor() {
+    this.id = 'REMOTE_MODULE_JS_CHECK';
+    this.description = `Disable the remote module`;
+    this.type = sourceTypes.JAVASCRIPT;
+    this.shortenedURL = "https://git.io/JvqrQ";
+  }
+
+  match(astNode, astHelper, scope){
+    if (astNode.type !== 'NewExpression') return null;
+    if (astNode.callee.name !== 'BrowserWindow' && astNode.callee.name !== 'BrowserView') return null;
+
+    let wasFound = false;
+    let loc = [];
+    if (astNode.arguments.length > 0) {
+
+      var target = scope.resolveVarValue(astNode);
+
+      const found_nodes = astHelper.findNodeByType(target,
+        astHelper.PropertyName,
+        astHelper.PropertyDepth,
+        false,
+        node => (node.key.value === 'enableRemoteModule' || node.key.name === 'enableRemoteModule'));
+
+      for (const node of found_nodes) {
+        wasFound = true;
+        if (node.value.value === false) {
+          continue;
+        }
+        loc.push({ line: node.key.loc.start.line, column: node.key.loc.start.column, id: this.id, description: this.description, shortenedURL: this.shortenedURL, severity: severity.MEDIUM, confidence: confidence.FIRM, manualReview: false });
+      }
+    }
+
+    if (wasFound) {
+      return loc;
+    } else { // default is module 'remote' enabled (assuming nodeIntegration:true), which is a misconfiguration
+      return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, shortenedURL: this.shortenedURL, severity: severity.MEDIUM, confidence: confidence.TENTATIVE, manualReview: true }];
+    }
+  }
+}

--- a/src/finder/checks/AtomicChecks/index.js
+++ b/src/finder/checks/AtomicChecks/index.js
@@ -26,6 +26,7 @@ import NodeIntegrationJSCheck from './NodeIntegrationJSCheck';
 import NodeIntegrationAttachEventJSCheck from './NodeIntegrationAttachEventJSCheck';
 import OpenExternalJSCheck from './OpenExternalJSCheck';
 import PermissionRequestHandlerJSCheck from './PermissionRequestHandlerJSCheck';
+import RemoteModuleJSCheck from './RemoteModuleJSCheck';
 import SandboxJSCheck from './SandboxJSCheck';
 import SecurityWarningsDisabledJSCheck from './SecurityWarningsDisabledJSCheck';
 import SecurityWarningsDisabledJSONCheck from './SecurityWarningsDisabledJSONCheck';
@@ -64,6 +65,7 @@ const CHECKS = [
   NodeIntegrationAttachEventJSCheck,
   OpenExternalJSCheck,
   PermissionRequestHandlerJSCheck,
+  RemoteModuleJSCheck,
   SandboxJSCheck,
   SecurityWarningsDisabledJSCheck,
   SecurityWarningsDisabledJSONCheck,

--- a/test/checks/AtomicChecks/REMOTE_MODULE_JS_CHECK_1_0.js
+++ b/test/checks/AtomicChecks/REMOTE_MODULE_JS_CHECK_1_0.js
@@ -1,0 +1,3 @@
+mainWindow = new BrowserWindow({ "webPreferences": {
+  "enableRemoteModule": false }
+});

--- a/test/checks/AtomicChecks/REMOTE_MODULE_JS_CHECK_1_0.ts
+++ b/test/checks/AtomicChecks/REMOTE_MODULE_JS_CHECK_1_0.ts
@@ -1,0 +1,14 @@
+import { BrowserWindow } from "electron";
+
+export default function initialize() {
+
+  let mainWindow: BrowserWindow | undefined;
+
+  function createWindow() {
+    mainWindow = new BrowserWindow({
+      "webPreferences": {
+        "enableRemoteModule": false
+      }
+    });
+  }
+}

--- a/test/checks/AtomicChecks/REMOTE_MODULE_JS_CHECK_2_1.js
+++ b/test/checks/AtomicChecks/REMOTE_MODULE_JS_CHECK_2_1.js
@@ -1,0 +1,3 @@
+mainWindow = new BrowserWindow({ "webPreferences": {
+  enableRemoteModule: true }
+});

--- a/test/checks/AtomicChecks/REMOTE_MODULE_JS_CHECK_2_1.ts
+++ b/test/checks/AtomicChecks/REMOTE_MODULE_JS_CHECK_2_1.ts
@@ -1,0 +1,12 @@
+import { BrowserWindow } from "electron";
+
+export default function initialize() {
+
+  let mainWindow: BrowserWindow | undefined;
+
+  function createWindow() {
+	mainWindow = new BrowserWindow({ "webPreferences": {
+		enableRemoteModule: true }
+	});
+  }
+}

--- a/test/checks/AtomicChecks/REMOTE_MODULE_JS_CHECK_3_2.js
+++ b/test/checks/AtomicChecks/REMOTE_MODULE_JS_CHECK_3_2.js
@@ -1,0 +1,11 @@
+const { BrowserView, BrowserWindow } = require('electron')
+
+let win = new BrowserWindow({ width: 800, height: 600 })
+win.on('closed', () => {
+  win = null
+})
+
+let view = new BrowserView()
+win.setBrowserView(view)
+view.setBounds({ x: 0, y: 0, width: 300, height: 300 })
+view.webContents.loadURL('https://electronjs.org')


### PR DESCRIPTION
During Covalence 2020 conf, I realized that we didn't have a check for `enableRemoteModule ` so here you have! 

@phosphore can you please review and merge, thanks!

More details in the wiki page --> https://github.com/doyensec/electronegativity/wiki/REMOTE_MODULE_JS_CHECK