### PR TITLE
Add Electron upgrade checks to Electronegativity

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ $ electronegativity -h
 | -o, --output <filename[.csv or .sarif]> | save the results to a file in csv or sarif format |
 | -r, --relative | show relative path for files |
 | -v, --verbose | show the description for the findings |
+| -u, --upgrade <current version..target version> | run Electron upgrade checks, eg -u 7..8 to check upgrade from Electron 7 to 8 |
 | -h, --help   | output usage information                          |
 
 
@@ -50,6 +51,11 @@ $ electronegativity -i /path/to/electron/app
 Using electronegativity to look for issues in an `asar` archive and saving the results in a csv file:
 ```
 $ electronegativity -i /path/to/asar/archive -o result.csv
+```
+
+Using electronegativity when upgrading from one version of Electron to another to find breaking changes:
+```
+$ electronegativity -i /path/to/electron/app -v -u 7..8
 ```
 
 Note: if you're running into the Fatal Error "JavaScript heap out of memory", you can run node using ```node --max-old-space-size=4096 electronegativity -i /path/to/asar/archive -o result.csv```

--- a/src/finder/checks/AtomicChecks/5/BrowserWindowWebPreferences.js
+++ b/src/finder/checks/AtomicChecks/5/BrowserWindowWebPreferences.js
@@ -1,0 +1,17 @@
+import { sourceTypes } from '../../../../parser/types';
+import { severity, confidence } from '../../../attributes';
+
+export default class BrowserWindowWebPreferences {
+  constructor() {
+    this.id = 'BROWSER_WINDOW_WEB_PREFERENCES_DEPRECATION';
+    this.description = '(ELECTRON 5) The BrowserWindow API\'s webPreferences option default values are deprecated in favor of the new defaults.';
+    this.type = sourceTypes.JAVASCRIPT;
+    this.shortenedURL = 'https://git.io/Jvahw';
+  }
+
+  match(astNode, astHelper, scope) {
+    if (astNode.type !== 'NewExpression') return null;
+    if (astNode.callee.name !== 'BrowserWindow' && astNode.callee.name !== 'BrowserView') return null;
+    return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, shortenedURL: this.shortenedURL, severity: severity.MEDIUM, confidence: confidence.TENTATIVE, manualReview: true }];
+  }
+}

--- a/src/finder/checks/AtomicChecks/5/NativeWindowOpen.js
+++ b/src/finder/checks/AtomicChecks/5/NativeWindowOpen.js
@@ -1,0 +1,37 @@
+import { sourceTypes } from '../../../../parser/types';
+import { severity, confidence } from '../../../attributes';
+
+export default class NativeWindowOpen {
+  constructor() {
+    this.id = 'NATIVE_WINDOW_OPEN_CHANGE';
+    this.description = `(ELECTRON 5) Child windows opened with the nativeWindowOpen option will always have Node.js integration disabled.`;
+    this.type = sourceTypes.JAVASCRIPT;
+    this.shortenedURL = "https://git.io/JvVeZ";
+  }
+
+  match(astNode, astHelper, scope){
+    if (astNode.type !== 'NewExpression') return null;
+    if (astNode.callee.name !== 'BrowserWindow' && astNode.callee.name !== 'BrowserView') return null;
+
+    let location = [];
+
+    if (astNode.arguments.length > 0) {
+      
+      var target = scope.resolveVarValue(astNode);
+
+      const found_nodes = astHelper.findNodeByType(target,
+        astHelper.PropertyName,
+        astHelper.PropertyDepth,
+        false,
+        node => (node.key.value === 'nativeWindowOpen' || node.key.name === 'nativeWindowOpen'));
+
+      for (const node of found_nodes) {
+        if (node.value.value) {
+          location.push({ line: node.key.loc.start.line, column: node.key.loc.start.column, id: this.id, description: this.description, shortenedURL: this.shortenedURL, severity: severity.MEDIUM, confidence: confidence.CERTAIN, manualReview: true });
+        }
+      }
+    }
+
+    return location;
+  }
+}

--- a/src/finder/checks/AtomicChecks/5/PrivilegedSchemesRegistrationRemoval.js
+++ b/src/finder/checks/AtomicChecks/5/PrivilegedSchemesRegistrationRemoval.js
@@ -12,7 +12,7 @@ export default class PrivilegedSchemesRegistrationRemoval {
   match(astNode, astHelper, scope){
     if (astNode.type !== 'CallExpression') return null;
     if (!astNode.callee.property ||  
-        (astNode.callee.property.name !== 'setRegisterURLSchemeAsPrivileged' &&
+        (astNode.callee.property.name !== 'registerURLSchemeAsPrivileged' &&
         astNode.callee.property.name !== 'registerURLSchemeAsBypassingCSP' &&
         astNode.callee.property.name !== 'registerStandardSchemes')) {
       return null;

--- a/src/finder/checks/AtomicChecks/5/PrivilegedSchemesRegistrationRemoval.js
+++ b/src/finder/checks/AtomicChecks/5/PrivilegedSchemesRegistrationRemoval.js
@@ -1,0 +1,22 @@
+import { sourceTypes } from '../../../../parser/types';
+import { severity, confidence } from '../../../attributes';
+
+export default class PrivilegedSchemesRegistrationRemoval {
+  constructor() {
+    this.id = 'PRIVILEGED_SCHEMES_REGISTRATION_REMOVAL';
+    this.description = '(ELECTRON 5) The APIs for Privileged Schemes Registration have been removed in favor of protocol.registerSchemesAsPrivileged.';
+    this.type = sourceTypes.JAVASCRIPT;
+    this.shortenedURL = 'https://git.io/JvVew';
+  }
+
+  match(astNode, astHelper, scope){
+    if (astNode.type !== 'CallExpression') return null;
+    if (!astNode.callee.property ||  
+        (astNode.callee.property.name !== 'setRegisterURLSchemeAsPrivileged' &&
+        astNode.callee.property.name !== 'registerURLSchemeAsBypassingCSP' &&
+        astNode.callee.property.name !== 'registerStandardSchemes')) {
+      return null;
+    }
+    return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, shortenedURL: this.shortenedURL, severity: severity.HIGH, confidence: confidence.CERTAIN, manualReview: false }];
+  }
+}

--- a/src/finder/checks/AtomicChecks/5/SetSpellCheckProviderDeprecation.js
+++ b/src/finder/checks/AtomicChecks/5/SetSpellCheckProviderDeprecation.js
@@ -1,0 +1,20 @@
+import { sourceTypes } from '../../../../parser/types';
+import { severity, confidence } from '../../../attributes';
+
+export default class SetSpellCheckProviderDeprecation {
+  constructor() {
+    this.id = 'SET_SPELLCHECK_PROVIDER_DEPRECATION';
+    this.description = '(ELECTRON 5) The spellCheck callback on webFrame.setSpellCheckProvider is now asynchronous, and autoCorrectWord parameter has been removed.';
+    this.type = sourceTypes.JAVASCRIPT;
+    this.shortenedURL = 'https://git.io/JvVv0';
+  }
+
+  match(astNode, astHelper, scope){
+    if (astNode.type !== 'CallExpression') return null;
+    if (!astNode.callee.property || 
+        astNode.callee.property.name !== 'setSpellCheckProvider') {
+      return null;
+    }
+    return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, shortenedURL: this.shortenedURL, severity: severity.HIGH, confidence: confidence.CERTAIN, manualReview: false }];
+  }
+}

--- a/src/finder/checks/AtomicChecks/5/WebFrameIsolatedWorldDeprecation.js
+++ b/src/finder/checks/AtomicChecks/5/WebFrameIsolatedWorldDeprecation.js
@@ -1,0 +1,22 @@
+import { sourceTypes } from '../../../../parser/types';
+import { severity, confidence } from '../../../attributes';
+
+export default class WebFrameIsolatedWorldDeprecation {
+  constructor() {
+    this.id = 'WEB_FRAME_ISOLATED_WORLD_DEPRECATION';
+    this.description = '(ELECTRON 5) The webFrame isolated world APIs have been deprecated in favor of webFrame.setIsolatedWorldInfo';
+    this.type = sourceTypes.JAVASCRIPT;
+    this.shortenedURL = 'https://git.io/JvVe2';
+  }
+
+  match(astNode, astHelper, scope){
+    if (astNode.type !== 'CallExpression') return null;
+    if (!astNode.callee.property || 
+        (astNode.callee.property.name !== 'setIsolatedWorldContentSecurityPolicy' &&
+        astNode.callee.property.name !== 'setIsolatedWorldHumanReadableName' &&
+        astNode.callee.property.name !== 'setIsolatedWorldSecurityOrigin')) {
+      return null;
+    }
+    return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, shortenedURL: this.shortenedURL, severity: severity.MEDIUM, confidence: confidence.CERTAIN, manualReview: false }];
+  }
+}

--- a/src/finder/checks/AtomicChecks/6/ContentTracingGetTraceBufferUsage.js
+++ b/src/finder/checks/AtomicChecks/6/ContentTracingGetTraceBufferUsage.js
@@ -1,0 +1,25 @@
+import { sourceTypes } from '../../../../parser/types';
+import { severity, confidence } from '../../../attributes';
+
+export default class ContentTracingGetTraceBufferUsage {
+  constructor() {
+    this.id = 'CONTENT_TRACING_GET_TRACE_BUFFER_USAGE_DEPRECATION';
+    this.description = '(ELECTRON 6) Calling contentTracing.getTraceBufferUsage() with a callback is deprecated.';
+    this.type = sourceTypes.JAVASCRIPT;
+    this.shortenedURL = 'https://git.io/JvaWM';
+  }
+
+  match(astNode, astHelper, scope){
+    if (astNode.type !== 'CallExpression') return null;
+    if (!(astNode.callee.property
+        && astNode.callee.property.name === 'getTraceBufferUsage')) {
+      return null;
+    }
+
+    if (astNode.arguments.length > 0) {      
+      return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, shortenedURL: this.shortenedURL, severity: severity.MEDIUM, confidence: confidence.CERTAIN, manualReview: false }];        
+    }
+
+    return null;
+  }
+}

--- a/src/finder/checks/AtomicChecks/6/EnableMixedSandboxDeprecation.js
+++ b/src/finder/checks/AtomicChecks/6/EnableMixedSandboxDeprecation.js
@@ -1,0 +1,20 @@
+import { sourceTypes } from '../../../../parser/types';
+import { severity, confidence } from '../../../attributes';
+
+export default class EnableMixedSandboxDeprecation {
+  constructor() {
+    this.id = 'ENABLE_MIXED_SANDBOX_DEPRECATION';
+    this.description = '(ELECTRON 6) The app.enableMixedSandbox API has been deprecated since mixed-sandbox mode is now enabled by default.';
+    this.type = sourceTypes.JAVASCRIPT;
+    this.shortenedURL = 'https://git.io/Jvapp';
+  }
+
+  match(astNode, astHelper, scope){
+    if (astNode.type !== 'CallExpression') return null;
+    if (!astNode.callee.property
+        || astNode.callee.property.name !== 'enableMixedSandbox') {
+      return null;
+    }
+    return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, shortenedURL: this.shortenedURL, severity: severity.MEDIUM, confidence: confidence.CERTAIN, manualReview: false }];
+  }
+}

--- a/src/finder/checks/AtomicChecks/6/QuerySystemIdleStateDeprecation.js
+++ b/src/finder/checks/AtomicChecks/6/QuerySystemIdleStateDeprecation.js
@@ -1,0 +1,20 @@
+import { sourceTypes } from '../../../../parser/types';
+import { severity, confidence } from '../../../attributes';
+
+export default class QuerySystemIdleState {
+  constructor() {
+    this.id = 'QUERY_SYSTEM_IDLE_STATE_DEPRECATION';
+    this.description = '(ELECTRON 6) The powerMonitor.querySystemIdleState API has been deprecated.';
+    this.type = sourceTypes.JAVASCRIPT;
+    this.shortenedURL = 'https://git.io/Jva8V';
+  }
+
+  match(astNode, astHelper, scope){
+    if (astNode.type !== 'CallExpression') return null;
+    if (!astNode.callee.property
+        || astNode.callee.property.name !== 'querySystemIdleState') {
+      return null;
+    }
+    return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, shortenedURL: this.shortenedURL, severity: severity.MEDIUM, confidence: confidence.CERTAIN, manualReview: false }];
+  }
+}

--- a/src/finder/checks/AtomicChecks/6/QuerySystemIdleTimeDeprecation.js
+++ b/src/finder/checks/AtomicChecks/6/QuerySystemIdleTimeDeprecation.js
@@ -1,0 +1,20 @@
+import { sourceTypes } from '../../../../parser/types';
+import { severity, confidence } from '../../../attributes';
+
+export default class QuerySystemIdleTime {
+  constructor() {
+    this.id = 'QUERY_SYSTEM_IDLE_TIME_DEPRECATION';
+    this.description = '(ELECTRON 6) The powerMonitor.querySystemIdleTime API has been deprecated.';
+    this.type = sourceTypes.JAVASCRIPT;
+    this.shortenedURL = 'https://git.io/Jva8w';
+  }
+
+  match(astNode, astHelper, scope){
+    if (astNode.type !== 'CallExpression') return null;
+    if (!astNode.callee.property
+        || astNode.callee.property.name !== 'querySystemIdleTime') {
+      return null;
+    }
+    return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, shortenedURL: this.shortenedURL, severity: severity.MEDIUM, confidence: confidence.CERTAIN, manualReview: false }];
+  }
+}

--- a/src/finder/checks/AtomicChecks/6/RequireElectronScreen.js
+++ b/src/finder/checks/AtomicChecks/6/RequireElectronScreen.js
@@ -9,12 +9,23 @@ export default class RequireElectronScreen {
     this.shortenedURL = 'https://git.io/JvalC';
   }
 
-  match(astNode, astHelper, scope){
-    if (astNode.type !== 'MemberExpression') return null;
-    if (!astNode.object || astNode.object.type !== 'CallExpression') return null;
-    if (!astNode.object.callee || astNode.object.callee.name !== 'require') return null;
-    if (!astNode.object.arguments || astNode.object.arguments[0].value !== 'electron') return null;
-    if (!astNode.property || astNode.property.name !== 'screen') return null;
-    return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, shortenedURL: this.shortenedURL, severity: severity.MEDIUM, confidence: confidence.TENTATIVE, manualReview: true }];
+  match(astNode, astHelper, scope){    
+    if (astNode.type !== 'VariableDeclarator') return null;    
+    if (!astNode.init || (astNode.init.type !== 'MemberExpression' && astNode.init.type !== 'CallExpression')) return null;
+    if (astNode.init.type === 'MemberExpression') {      
+      if (!astNode.init.object.callee || astNode.init.object.callee.name !== 'require') return null;
+      if (!astNode.init.object.arguments || astNode.init.object.arguments[0].value !== 'electron') return null;
+      if (!astNode.init.property || astNode.init.property.name !== 'screen') return null;
+      return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, shortenedURL: this.shortenedURL, severity: severity.MEDIUM, confidence: confidence.TENTATIVE, manualReview: true }];
+    } else {
+      if (!astNode.init.callee || astNode.init.callee.name !== 'require') return null;
+      if (!astNode.init.arguments || astNode.init.arguments[0].value !== 'electron') return null;
+      if (!astNode.id || astNode.id.type !== 'ObjectPattern') return null;
+      for (const property of astNode.id.properties) {
+        if (property.key && property.key.name && property.key.name === 'screen') {
+          return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, shortenedURL: this.shortenedURL, severity: severity.MEDIUM, confidence: confidence.TENTATIVE, manualReview: true }];
+        }
+      }
+    }
   }
 }

--- a/src/finder/checks/AtomicChecks/6/RequireElectronScreen.js
+++ b/src/finder/checks/AtomicChecks/6/RequireElectronScreen.js
@@ -1,0 +1,20 @@
+import { sourceTypes } from '../../../../parser/types';
+import { severity, confidence } from '../../../attributes';
+
+export default class RequireElectronScreen {
+  constructor() {
+    this.id = 'REQUIRE_ELECTRON_SCREEN_DEPRECATION';
+    this.description = '(ELECTRON 6) require(\'electron\').screen in the renderer process is deprecated.';
+    this.type = sourceTypes.JAVASCRIPT;
+    this.shortenedURL = 'https://git.io/JvalC';
+  }
+
+  match(astNode, astHelper, scope){
+    if (astNode.type !== 'MemberExpression') return null;
+    if (!astNode.object || astNode.object.type !== 'CallExpression') return null;
+    if (!astNode.object.callee || astNode.object.callee.name !== 'require') return null;
+    if (!astNode.object.arguments || astNode.object.arguments[0].value !== 'electron') return null;
+    if (!astNode.property || astNode.property.name !== 'screen') return null;
+    return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, shortenedURL: this.shortenedURL, severity: severity.MEDIUM, confidence: confidence.TENTATIVE, manualReview: true }];
+  }
+}

--- a/src/finder/checks/AtomicChecks/6/RequireSandboxedRenderers.js
+++ b/src/finder/checks/AtomicChecks/6/RequireSandboxedRenderers.js
@@ -1,0 +1,22 @@
+import { sourceTypes } from '../../../../parser/types';
+import { severity, confidence } from '../../../attributes';
+
+const DEPRECATED_REQUIRES = [ 'child_process', 'fs', 'os', 'path' ]
+
+export default class RequireSandboxedRenderers {
+  constructor() {
+    this.id = 'REQUIRE_SANDBOXED_RENDERERS_DEPRECATION';
+    this.description = '(ELECTRON 6) Certain requires in sandboxed renderers are deprecated.';
+    this.type = sourceTypes.JAVASCRIPT;
+    this.shortenedURL = 'https://git.io/JvalR';
+  }
+
+  match(astNode, astHelper, scope){
+    if (astNode.type !== 'ExpressionStatement') return null;
+    if (!astNode.expression || astNode.expression.type !== 'CallExpression') return null;
+    if (!astNode.expression.callee || astNode.expression.callee.name !== 'require') return null;
+    if (!astNode.expression.arguments || astNode.expression.arguments[0].type !== astHelper.StringLiteral) return null;
+    if (DEPRECATED_REQUIRES.indexOf(astNode.expression.arguments[0].value) === -1) return null;
+    return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, shortenedURL: this.shortenedURL, severity: severity.MEDIUM, confidence: confidence.TENTATIVE, manualReview: true }];
+  }
+}

--- a/src/finder/checks/AtomicChecks/6/RequireSandboxedRenderers.js
+++ b/src/finder/checks/AtomicChecks/6/RequireSandboxedRenderers.js
@@ -12,11 +12,10 @@ export default class RequireSandboxedRenderers {
   }
 
   match(astNode, astHelper, scope){
-    if (astNode.type !== 'ExpressionStatement') return null;
-    if (!astNode.expression || astNode.expression.type !== 'CallExpression') return null;
-    if (!astNode.expression.callee || astNode.expression.callee.name !== 'require') return null;
-    if (!astNode.expression.arguments || astNode.expression.arguments[0].type !== astHelper.StringLiteral) return null;
-    if (DEPRECATED_REQUIRES.indexOf(astNode.expression.arguments[0].value) === -1) return null;
+    if (astNode.type !== 'CallExpression') return null;
+    if (!astNode.callee || astNode.callee.name !== 'require') return null;
+    if (!astNode.arguments || astNode.arguments[0].type !== astHelper.StringLiteral) return null;
+    if (DEPRECATED_REQUIRES.indexOf(astNode.arguments[0].value) === -1) return null;
     return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, shortenedURL: this.shortenedURL, severity: severity.MEDIUM, confidence: confidence.TENTATIVE, manualReview: true }];
   }
 }

--- a/src/finder/checks/AtomicChecks/6/SetHighlightModeDeprecation.js
+++ b/src/finder/checks/AtomicChecks/6/SetHighlightModeDeprecation.js
@@ -1,0 +1,20 @@
+import { sourceTypes } from '../../../../parser/types';
+import { severity, confidence } from '../../../attributes';
+
+export default class SetHighlightModeDeprecation {
+  constructor() {
+    this.id = 'SET_HIGHLIGHT_MODE_DEPRECATION';
+    this.description = '(ELECTRON 6) The tray.setHighlightMode API has been deprecated.';
+    this.type = sourceTypes.JAVASCRIPT;
+    this.shortenedURL = 'https://git.io/Jva8p';
+  }
+
+  match(astNode, astHelper, scope){
+    if (astNode.type !== 'CallExpression') return null;
+    if (!astNode.callee.property
+        || astNode.callee.property.name !== 'setHighlightMode') {
+      return null;
+    }
+    return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, shortenedURL: this.shortenedURL, severity: severity.MEDIUM, confidence: confidence.CERTAIN, manualReview: false }];
+  }
+}

--- a/src/finder/checks/AtomicChecks/6/SetNullMenuDeprecation.js
+++ b/src/finder/checks/AtomicChecks/6/SetNullMenuDeprecation.js
@@ -1,0 +1,27 @@
+import { sourceTypes } from '../../../../parser/types';
+import { severity, confidence } from '../../../attributes';
+
+export default class SetNullMenuDeprecation {
+  constructor() {
+    this.id = 'SET_NULL_MENU_DEPRECATION';
+    this.description = '(ELECTRON 6) Calling win.setMenu(null) to remove a menu has been deprecated in favor of win.removeMenu().';
+    this.type = sourceTypes.JAVASCRIPT;
+    this.shortenedURL = 'https://git.io/JvVkc';
+  }
+
+  match(astNode, astHelper, scope){
+    if (astNode.type !== 'CallExpression') return null;
+    if (!(astNode.callee.property
+        && astNode.callee.property.name === 'setMenu')) {
+      return null;
+    }
+
+    let confidenceLevel = confidence.TENTATIVE
+    if (astNode.arguments.length > 0) {
+      if (astNode.arguments[0].value === null){
+        confidenceLevel = confidence.CERTAIN
+      }      
+    }
+    return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, shortenedURL: this.shortenedURL, severity: severity.MEDIUM, confidence: confidenceLevel, manualReview: true }];
+  }
+}

--- a/src/finder/checks/AtomicChecks/7/ClearAuthCache.js
+++ b/src/finder/checks/AtomicChecks/7/ClearAuthCache.js
@@ -1,0 +1,25 @@
+import { sourceTypes } from '../../../../parser/types';
+import { severity, confidence } from '../../../attributes';
+
+export default class ClearAuthCache {
+  constructor() {
+    this.id = 'CLEAR_AUTH_CACHE_DEPRECATION';
+    this.description = '(ELECTRON 7) The session.clearAuthCache API no longer accepts options for what to clear, and instead unconditionally clears the whole cache.';
+    this.type = sourceTypes.JAVASCRIPT;
+    this.shortenedURL = 'https://git.io/Jvuxg';
+  }
+
+  match(astNode, astHelper, scope){
+    if (astNode.type !== 'CallExpression') return null;
+    if (!(astNode.callee.property
+        && astNode.callee.property.name === 'clearAuthCache')) {
+      return null;
+    }
+
+    if (astNode.arguments.length > 0) {      
+      return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, shortenedURL: this.shortenedURL, severity: severity.MEDIUM, confidence: confidence.CERTAIN, manualReview: false }];        
+    }
+
+    return null;
+  }
+}

--- a/src/finder/checks/AtomicChecks/7/ContentTracingGetTraceBufferUsageRemoval.js
+++ b/src/finder/checks/AtomicChecks/7/ContentTracingGetTraceBufferUsageRemoval.js
@@ -1,0 +1,25 @@
+import { sourceTypes } from '../../../../parser/types';
+import { severity, confidence } from '../../../attributes';
+
+export default class ContentTracingGetTraceBufferUsageRemoval {
+  constructor() {
+    this.id = 'CONTENT_TRACING_GET_TRACE_BUFFER_USAGE_REMOVAL';
+    this.description = '(ELECTRON 7) Calling contentTracing.getTraceBufferUsage() with a callback has been removed.';
+    this.type = sourceTypes.JAVASCRIPT;
+    this.shortenedURL = 'https://git.io/JvaWM';
+  }
+
+  match(astNode, astHelper, scope){
+    if (astNode.type !== 'CallExpression') return null;
+    if (!(astNode.callee.property
+        && astNode.callee.property.name === 'getTraceBufferUsage')) {
+      return null;
+    }
+
+    if (astNode.arguments.length > 0) {      
+      return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, shortenedURL: this.shortenedURL, severity: severity.MEDIUM, confidence: confidence.CERTAIN, manualReview: false }];        
+    }
+
+    return null;
+  }
+}

--- a/src/finder/checks/AtomicChecks/7/EnableMixedSandboxRemoval.js
+++ b/src/finder/checks/AtomicChecks/7/EnableMixedSandboxRemoval.js
@@ -1,0 +1,20 @@
+import { sourceTypes } from '../../../../parser/types';
+import { severity, confidence } from '../../../attributes';
+
+export default class EnableMixedSandboxRemoval {
+  constructor() {
+    this.id = 'ENABLE_MIXED_SANDBOX_REMOVAL';
+    this.description = '(ELECTRON 7) The app.enableMixedSandbox API has been removed since mixed-sandbox mode is now enabled by default.';
+    this.type = sourceTypes.JAVASCRIPT;
+    this.shortenedURL = 'https://git.io/Jvapp';
+  }
+
+  match(astNode, astHelper, scope){
+    if (astNode.type !== 'CallExpression') return null;
+    if (!astNode.callee.property
+        || astNode.callee.property.name !== 'enableMixedSandbox') {
+      return null;
+    }
+    return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, shortenedURL: this.shortenedURL, severity: severity.MEDIUM, confidence: confidence.CERTAIN, manualReview: false }];
+  }
+}

--- a/src/finder/checks/AtomicChecks/7/QuerySystemIdleState.js
+++ b/src/finder/checks/AtomicChecks/7/QuerySystemIdleState.js
@@ -1,0 +1,20 @@
+import { sourceTypes } from '../../../../parser/types';
+import { severity, confidence } from '../../../attributes';
+
+export default class QuerySystemIdleState {
+  constructor() {
+    this.id = 'QUERY_SYSTEM_IDLE_STATE_REMOVAL';
+    this.description = '(ELECTRON 7) The powerMonitor.querySystemIdleState API has been replaced with the synchronous API powerMonitor.getSystemIdleState.';
+    this.type = sourceTypes.JAVASCRIPT;
+    this.shortenedURL = 'https://git.io/Jvuxw';
+  }
+
+  match(astNode, astHelper, scope){
+    if (astNode.type !== 'CallExpression') return null;
+    if (!astNode.callee.property
+        || astNode.callee.property.name !== 'querySystemIdleState') {
+      return null;
+    }
+    return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, shortenedURL: this.shortenedURL, severity: severity.HIGH, confidence: confidence.CERTAIN, manualReview: false }];
+  }
+}

--- a/src/finder/checks/AtomicChecks/7/QuerySystemIdleTime.js
+++ b/src/finder/checks/AtomicChecks/7/QuerySystemIdleTime.js
@@ -1,0 +1,20 @@
+import { sourceTypes } from '../../../../parser/types';
+import { severity, confidence } from '../../../attributes';
+
+export default class QuerySystemIdleTime {
+  constructor() {
+    this.id = 'QUERY_SYSTEM_IDLE_TIME_REMOVAL';
+    this.description = '(ELECTRON 7) The powerMonitor.querySystemIdleTime API has been replaced with the synchronous API powerMonitor.getSystemIdleTime.';
+    this.type = sourceTypes.JAVASCRIPT;
+    this.shortenedURL = 'https://git.io/Jvuxo';
+  }
+
+  match(astNode, astHelper, scope){
+    if (astNode.type !== 'CallExpression') return null;
+    if (!astNode.callee.property
+        || astNode.callee.property.name !== 'querySystemIdleTime') {
+      return null;
+    }
+    return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, shortenedURL: this.shortenedURL, severity: severity.HIGH, confidence: confidence.CERTAIN, manualReview: false }];
+  }
+}

--- a/src/finder/checks/AtomicChecks/7/SetHighlightModeRemoval.js
+++ b/src/finder/checks/AtomicChecks/7/SetHighlightModeRemoval.js
@@ -1,0 +1,20 @@
+import { sourceTypes } from '../../../../parser/types';
+import { severity, confidence } from '../../../attributes';
+
+export default class SetHighlightModeRemoval {
+  constructor() {
+    this.id = 'SET_HIGHLIGHT_MODE_REMOVAL';
+    this.description = '(ELECTRON 7) The tray.setHighlightMode API has been removed.';
+    this.type = sourceTypes.JAVASCRIPT;
+    this.shortenedURL = 'https://git.io/Jva8j';
+  }
+
+  match(astNode, astHelper, scope){
+    if (astNode.type !== 'CallExpression') return null;
+    if (!astNode.callee.property
+        || astNode.callee.property.name !== 'setHighlightMode') {
+      return null;
+    }
+    return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, shortenedURL: this.shortenedURL, severity: severity.MEDIUM, confidence: confidence.CERTAIN, manualReview: false }];
+  }
+}

--- a/src/finder/checks/AtomicChecks/7/WebFrameIsolatedWorldRemoval.js
+++ b/src/finder/checks/AtomicChecks/7/WebFrameIsolatedWorldRemoval.js
@@ -1,0 +1,22 @@
+import { sourceTypes } from '../../../../parser/types';
+import { severity, confidence } from '../../../attributes';
+
+export default class WebFrameIsolatedWorldRemoval {
+  constructor() {
+    this.id = 'WEB_FRAME_ISOLATED_WORLD_REMOVAL';
+    this.description = '(ELECTRON 7) The webFrame isolated world APIs have been removed in favor of webFrame.setIsolatedWorldInfo';
+    this.type = sourceTypes.JAVASCRIPT;
+    this.shortenedURL = 'https://git.io/JvaCG';
+  }
+
+  match(astNode, astHelper, scope){
+    if (astNode.type !== 'CallExpression') return null;
+    if (!astNode.callee.property || 
+        (astNode.callee.property.name !== 'setIsolatedWorldContentSecurityPolicy' &&
+        astNode.callee.property.name !== 'setIsolatedWorldHumanReadableName' &&
+        astNode.callee.property.name !== 'setIsolatedWorldSecurityOrigin')) {
+      return null;
+    }
+    return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, shortenedURL: this.shortenedURL, severity: severity.HIGH, confidence: confidence.CERTAIN, manualReview: false }];
+  }
+}

--- a/src/finder/checks/AtomicChecks/7/WebKitDirectoryChange.js
+++ b/src/finder/checks/AtomicChecks/7/WebKitDirectoryChange.js
@@ -1,0 +1,21 @@
+import { sourceTypes } from '../../../../parser/types';
+import { severity, confidence } from '../../../attributes';
+
+export default class WebKitDirectoryChange {
+  constructor() {
+    this.id = 'WEBKITDIRECTORY_CHANGE';
+    this.description = `Fixed webkitdirectory to return list of files if a folder is selected.`;
+    this.type = sourceTypes.HTML;
+    this.shortenedURL = "https://git.io/JvVIu";
+  }
+
+  match(cheerioObj, content) {
+    const loc = [];
+    const inputs = cheerioObj('input[webkitdirectory]');
+    const self = this;
+    inputs.each(function (i, elem) {
+      loc.push({ line: content.substr(0, elem.startIndex).split('\n').length, column: 0, id: self.id, description: self.description, shortenedURL: self.shortenedURL, severity: severity.MEDIUM, confidence: confidence.CERTAIN, manualReview: false });
+    });
+    return loc;
+  }
+}

--- a/src/finder/checks/AtomicChecks/8/AllowRendererProcessReuse.js
+++ b/src/finder/checks/AtomicChecks/8/AllowRendererProcessReuse.js
@@ -1,0 +1,18 @@
+import { sourceTypes } from '../../../../parser/types';
+import { severity, confidence } from '../../../attributes';
+
+export default class AllowRendererProcessReuse {
+  constructor() {
+    this.id = 'ALLOW_RENDERER_PROCESS_REUSE_DEPRECATION';
+    this.description = '(ELECTRON 8) The default value of false for app.allowRendererProcessReuse is deprecated.'
+    this.type = sourceTypes.JAVASCRIPT;
+    this.shortenedURL = 'https://git.io/JvuxX';
+  }
+
+  match(astNode, astHelper, scope){
+    if (!astNode.property || astNode.property.name !== 'allowRendererProcessReuse') return null;
+    return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, shortenedURL: this.shortenedURL, severity: severity.MEDIUM, confidence: confidence.CERTAIN, manualReview: false }];
+
+  }
+}
+

--- a/src/finder/checks/AtomicChecks/8/GetColor.js
+++ b/src/finder/checks/AtomicChecks/8/GetColor.js
@@ -1,0 +1,33 @@
+import { sourceTypes } from '../../../../parser/types';
+import { severity, confidence } from '../../../attributes';
+
+export default class GetColor {
+  constructor() {
+    this.id = 'GET_COLOR_DEPRECATION';
+    this.description = '(ELECTRON 8) The color alternate-selected-control-text on systemPreferences.getColor(color) is deprecated';
+    this.type = sourceTypes.JAVASCRIPT;
+    this.shortenedURL = 'https://git.io/JvuxH';
+  }
+
+  match(astNode, astHelper, scope){
+    if (astNode.type !== 'CallExpression') return null;
+    if (!(astNode.callee.object && astNode.callee.object.name === 'systemPreferences')) {
+      return null;
+    }
+    if (!(astNode.callee.property
+        && astNode.callee.property.name === 'getColor')) {
+      return null;
+    }
+
+    let location = [];
+
+    if (astNode.arguments.length > 0) {
+        if (astNode.arguments[0].type !== astHelper.StringLiteral) return null;
+        if (astNode.arguments[0].value === 'alternate-selected-control-text') {
+          return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, shortenedURL: this.shortenedURL, severity: severity.MEDIUM, confidence: confidence.CERTAIN, manualReview: false }];
+        }
+    }
+
+    return location;
+  }
+}

--- a/src/finder/checks/AtomicChecks/8/GetWebContents.js
+++ b/src/finder/checks/AtomicChecks/8/GetWebContents.js
@@ -1,0 +1,20 @@
+import { sourceTypes } from '../../../../parser/types';
+import { severity, confidence } from '../../../attributes';
+
+export default class GetWebContents {
+  constructor() {
+    this.id = 'GET_WEB_CONTENTS_DEPRECATION';
+    this.description = '(ELECTRON 8) getWebContents is deprecated on the <webview> tag.';
+    this.type = sourceTypes.JAVASCRIPT;
+    this.shortenedURL = 'https://git.io/Jvux7';
+  }
+
+  match(astNode, astHelper, scope){
+    if (astNode.type !== 'CallExpression') return null;
+    if (!astNode.callee.property || astNode.callee.property.name !== 'getWebContents') {
+      return null;
+    }
+    return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, shortenedURL: this.shortenedURL, severity: severity.MEDIUM, confidence: confidence.CERTAIN, manualReview: false }];
+
+  }
+}

--- a/src/finder/checks/AtomicChecks/8/IPCSend.js
+++ b/src/finder/checks/AtomicChecks/8/IPCSend.js
@@ -1,0 +1,20 @@
+import { sourceTypes } from '../../../../parser/types';
+import { severity, confidence } from '../../../attributes';
+
+export default class IPCSend {
+  constructor() {
+    this.id = 'IPC_SEND_STRUCTURED_CLONE_ALGORITHM';
+    this.description = '(ELECTRON 8) Values sent over IPC are now serialized with Structured Clone Algorithm.';
+    this.type = sourceTypes.JAVASCRIPT;
+    this.shortenedURL = 'https://git.io/Jvuxd';
+  }
+
+  match(astNode, astHelper, scope){
+    if (astNode.type !== 'CallExpression') return null;
+    if (!astNode.callee.property || astNode.callee.property.name !== 'send') {
+      return null;
+    }
+    return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, shortenedURL: this.shortenedURL, severity: severity.MEDIUM, confidence: confidence.TENTATIVE, manualReview: true }];
+
+  }
+}

--- a/src/finder/checks/AtomicChecks/8/SetLayoutZoomLevelLimits.js
+++ b/src/finder/checks/AtomicChecks/8/SetLayoutZoomLevelLimits.js
@@ -1,0 +1,20 @@
+import { sourceTypes } from '../../../../parser/types';
+import { severity, confidence } from '../../../attributes';
+
+export default class SetLayoutZoomLevelLimits {
+  constructor() {
+    this.id = 'SET_ZOOM_LEVEL_LIMITS_DEPRECATION';
+    this.description = '(ELECTRON 8) setLayoutZoomLevelLimits is deprecated on webContents, webFrame, and the <webview> tag because Chromium removed this capability.';
+    this.type = sourceTypes.JAVASCRIPT;
+    this.shortenedURL = 'https://git.io/JvuxN';
+  }
+
+  match(astNode, astHelper, scope){
+    if (astNode.type !== 'CallExpression') return null;
+    if (!astNode.callee.property || astNode.callee.property.name !== 'setLayoutZoomLevelLimits') {
+      return null;
+    }
+    return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, shortenedURL: this.shortenedURL, severity: severity.MEDIUM, confidence: confidence.CERTAIN, manualReview: false }];
+
+  }
+}

--- a/src/finder/checks/AtomicChecks/8/VisibleOnFullScreen.js
+++ b/src/finder/checks/AtomicChecks/8/VisibleOnFullScreen.js
@@ -1,0 +1,37 @@
+import { sourceTypes } from '../../../../parser/types';
+import { severity, confidence } from '../../../attributes';
+
+export default class VisibleOnFullScreen {
+  constructor() {
+    this.id = 'VISIBLE_ON_FULLSCREEN_DEPRECATION';
+    this.description = `(ELECTRON 8) The option visibleOnFullScreen on BrowserWindow.setVisibleOnAllWorkspaces is deprecated`;
+    this.type = sourceTypes.JAVASCRIPT;
+    this.shortenedURL = 'https://git.io/Jvuxx';
+  }
+
+  match(astNode, astHelper, scope){
+    if (astNode.type !== 'CallExpression') return null;
+    if (!astNode.callee.property || astNode.callee.property.name !== 'setVisibleOnAllWorkspaces') {
+      return null;
+    }
+
+    let location = [];
+
+    if (astNode.arguments.length > 0) {
+      if (astNode.arguments.length > 1) {
+        if (astNode.arguments[1].type !== 'ObjectExpression') return null;
+        const found_nodes = astHelper.findNodeByType(astNode.arguments[1],
+          astHelper.PropertyName,
+          astHelper.PropertyDepth,
+          false,
+          node => (node.key.name === 'visibleOnFullScreen'));
+
+        for (const node of found_nodes) {
+            location.push({ line: node.key.loc.start.line, column: node.key.loc.start.column, id: this.id, description: this.description, shortenedURL: this.shortenedURL, severity: severity.MEDIUM, confidence: confidence.CERTAIN, manualReview: false });
+        }
+      }
+    }
+
+    return location;
+  }
+}

--- a/src/finder/checks/AtomicChecks/ElectronAtomicUpgradeChecks.js
+++ b/src/finder/checks/AtomicChecks/ElectronAtomicUpgradeChecks.js
@@ -1,0 +1,67 @@
+import BrowserWindowWebPreferences from './5/BrowserWindowWebPreferences';
+import NativeWindowOpen from './5/NativeWindowOpen';
+import PrivilegedSchemesRegistrationRemoval from './5/PrivilegedSchemesRegistrationRemoval';
+import SetSpellCheckProviderDeprecation from './5/SetSpellCheckProviderDeprecation';
+import WebFrameIsolatedWorldDeprecation from './5/WebFrameIsolatedWorldDeprecation';
+import ContentTracingGetTraceBufferUsage from './6/ContentTracingGetTraceBufferUsage';
+import EnableMixedSandboxDeprecation from './6/EnableMixedSandboxDeprecation';
+import QuerySystemIdleStateDeprecation from './6/QuerySystemIdleStateDeprecation';
+import QuerySystemIdleTimeDeprecation from './6/QuerySystemIdleTimeDeprecation';
+import RequireElectronScreen from './6/RequireElectronScreen';
+import RequireSandboxedRenderers from './6/RequireSandboxedRenderers';
+import SetHighlightModeDeprecation from './6/SetHighlightModeDeprecation';
+import SetNullMenuDeprecation from './6/SetNullMenuDeprecation';
+import ClearAuthCache from './7/ClearAuthCache';
+import ContentTracingGetTraceBufferUsageRemoval from './7/ContentTracingGetTraceBufferUsageRemoval';
+import EnableMixedSandboxRemoval from './7/EnableMixedSandboxRemoval';
+import QuerySystemIdleState from './7/QuerySystemIdleState';
+import QuerySystemIdleTime from './7/QuerySystemIdleTime';
+import SetHighlightModeRemoval from './7/SetHighlightModeRemoval';
+import WebFrameIsolatedWorldRemoval from './7/WebFrameIsolatedWorldRemoval';
+import WebKitDirectoryChange from './7/WebKitDirectoryChange';
+import AllowRendererProcessReuse from './8/AllowRendererProcessReuse';
+import GetColor from './8/GetColor';
+import GetWebContents from './8/GetWebContents';
+import IPCSend from './8/IPCSend';
+import SetLayoutZoomLevelLimits from './8/SetLayoutZoomLevelLimits';
+import VisibleOnFullScreen from './8/VisibleOnFullScreen';
+
+const ELECTRON_ATOMIC_UPGRADE_CHECKS = {
+    5: [
+      BrowserWindowWebPreferences,
+      NativeWindowOpen,
+      PrivilegedSchemesRegistrationRemoval,
+      SetSpellCheckProviderDeprecation,
+      WebFrameIsolatedWorldDeprecation
+    ],
+    6: [
+      ContentTracingGetTraceBufferUsage,
+      EnableMixedSandboxDeprecation,
+      QuerySystemIdleStateDeprecation,
+      QuerySystemIdleTimeDeprecation,
+      RequireElectronScreen,
+      RequireSandboxedRenderers,
+      SetNullMenuDeprecation,      
+      SetHighlightModeDeprecation
+    ],
+    7: [
+      ClearAuthCache,
+      ContentTracingGetTraceBufferUsageRemoval,
+      EnableMixedSandboxRemoval,
+      QuerySystemIdleState,
+      QuerySystemIdleTime,
+      SetHighlightModeRemoval,
+      WebFrameIsolatedWorldRemoval,
+      WebKitDirectoryChange
+    ],
+    8: [
+      AllowRendererProcessReuse,
+      GetColor,
+      GetWebContents,
+      IPCSend,
+      SetLayoutZoomLevelLimits,
+      VisibleOnFullScreen
+    ]
+  };
+
+module.exports.ELECTRON_ATOMIC_UPGRADE_CHECKS = ELECTRON_ATOMIC_UPGRADE_CHECKS;

--- a/src/finder/checks/GlobalChecks/8/AllowRendererProcessReuseGlobal.js
+++ b/src/finder/checks/GlobalChecks/8/AllowRendererProcessReuseGlobal.js
@@ -1,0 +1,20 @@
+import * as attributes from '../../../attributes';
+
+export default class AllowRendererProcessReuseGlobal {
+
+  constructor() {
+    this.id = 'ALLOW_RENDERER_PROCESS_REUSE_GLOBAL_DEPRECATION';
+    this.description = '(ELECTRON 8) The default value of app.allowRendererProcessReuse is deprecated, it is currently "false".  It will changed to be "true" in Electron 9.';
+    this.depends = ["AllowRendererProcessReuse"];
+    this.shortenedURL = 'https://git.io/JvuxX';
+  }
+
+  async perform(issues) {
+    var existingIssue = issues.filter(e => e.id === 'ALLOW_RENDERER_PROCESS_REUSE_DEPRECATION');
+    if (existingIssue.length === 0) {
+      // app.allowRendererProcessReuse isn't explicitly set - warn
+      issues.push({ file: "N/A", location: {line: 0, column: 0}, id: this.id, description: this.description, shortenedURL: this.shortenedURL, severity: attributes.severity.MEDIUM, confidence: attributes.confidence.CERTAIN, manualReview: false });      
+    }
+    return issues;
+  }
+}

--- a/src/finder/checks/GlobalChecks/ElectronGlobalUpgradeChecks.js
+++ b/src/finder/checks/GlobalChecks/ElectronGlobalUpgradeChecks.js
@@ -1,0 +1,9 @@
+import AllowRendererProcessReuseGlobal from './8/AllowRendererProcessReuseGlobal';
+
+const ELECTRON_GLOBAL_UPGRADE_CHECKS = {
+    8: [
+      AllowRendererProcessReuseGlobal
+    ]
+  };
+
+module.exports.ELECTRON_GLOBAL_UPGRADE_CHECKS = ELECTRON_GLOBAL_UPGRADE_CHECKS;

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,7 @@ program
   .option('-o, --output <filename[.csv | .sarif]>', 'save the results to a file in csv or sarif format')
   .option('-r, --relative', 'show relative path for files')
   .option('-v, --verbose', 'show the description for the findings')
+  .option('-u, --upgrade <current version..target version>', 'run Electron upgrade checks, eg -u 7..8')
   .parse(process.argv);
 
 if(!program.input){
@@ -59,4 +60,14 @@ else
 
 const input = path.resolve(program.input);
 
-run(input, program.output, program.fileFormat === 'sarif', program.checks, program.severity, program.confidence, program.relative, program.verbose);
+run({
+  input,
+  output: program.output, 
+  isSarif: program.fileFormat === 'sarif',
+  customScan: program.checks,
+  severitySet: program.severity, 
+  confidenceSet: program.confidence,
+  isRelative: program.relative,
+  isVerbose: program.verbose,
+  electronUpgrade: program.upgrade
+});

--- a/test/checks/AtomicChecks/ALLOW_RENDERER_PROCESS_REUSE_DEPRECATION_1_2.js
+++ b/test/checks/AtomicChecks/ALLOW_RENDERER_PROCESS_REUSE_DEPRECATION_1_2.js
@@ -1,0 +1,2 @@
+app.allowRendererProcessReuse = true
+app.allowRendererProcessReuse = false

--- a/test/checks/AtomicChecks/BROWSER_WINDOW_WEB_PREFERENCES_DEPRECATION_1_2.js
+++ b/test/checks/AtomicChecks/BROWSER_WINDOW_WEB_PREFERENCES_DEPRECATION_1_2.js
@@ -1,0 +1,12 @@
+const w = new BrowserWindow({
+  webPreferences: {
+    webviewTag: true
+  }
+});
+
+const bv = new BrowserView({
+  webPreferences: {
+    nodeIntegration: false
+  }
+});
+

--- a/test/checks/AtomicChecks/CLEAR_AUTH_CACHE_DEPRECATION_1_1.js
+++ b/test/checks/AtomicChecks/CLEAR_AUTH_CACHE_DEPRECATION_1_1.js
@@ -1,0 +1,2 @@
+session.clearAuthCache({ type: 'password' });
+session.clearAuthCache();

--- a/test/checks/AtomicChecks/CONTENT_TRACING_GET_TRACE_BUFFER_USAGE_DEPRECATION_1_1.js
+++ b/test/checks/AtomicChecks/CONTENT_TRACING_GET_TRACE_BUFFER_USAGE_DEPRECATION_1_1.js
@@ -1,0 +1,4 @@
+
+contentTracing.getTraceBufferUsage((percentage, value) => {
+ console.log('Got TraceBufferUsage');
+});

--- a/test/checks/AtomicChecks/CONTENT_TRACING_GET_TRACE_BUFFER_USAGE_REMOVAL_1_1.js
+++ b/test/checks/AtomicChecks/CONTENT_TRACING_GET_TRACE_BUFFER_USAGE_REMOVAL_1_1.js
@@ -1,0 +1,4 @@
+
+contentTracing.getTraceBufferUsage((percentage, value) => {
+ console.log('Got TraceBufferUsage');
+});

--- a/test/checks/AtomicChecks/ENABLE_MIXED_SANDBOX_DEPRECATION_1_1.js
+++ b/test/checks/AtomicChecks/ENABLE_MIXED_SANDBOX_DEPRECATION_1_1.js
@@ -1,0 +1,1 @@
+app.enableMixedSandbox();

--- a/test/checks/AtomicChecks/ENABLE_MIXED_SANDBOX_REMOVAL_1_1.js
+++ b/test/checks/AtomicChecks/ENABLE_MIXED_SANDBOX_REMOVAL_1_1.js
@@ -1,0 +1,1 @@
+app.enableMixedSandbox();

--- a/test/checks/AtomicChecks/GET_COLOR_DEPRECATION_1_1.js
+++ b/test/checks/AtomicChecks/GET_COLOR_DEPRECATION_1_1.js
@@ -1,0 +1,2 @@
+const altColor = systemPreferences.getColor('alternate-selected-control-text');
+const controlColor = systemPreferences.getColor('control');

--- a/test/checks/AtomicChecks/GET_WEB_CONTENTS_DEPRECATION_1_1.js
+++ b/test/checks/AtomicChecks/GET_WEB_CONTENTS_DEPRECATION_1_1.js
@@ -1,0 +1,1 @@
+const contents = webview.getWebContents();

--- a/test/checks/AtomicChecks/IPC_SEND_STRUCTURED_CLONE_ALGORITHM_1_1.js
+++ b/test/checks/AtomicChecks/IPC_SEND_STRUCTURED_CLONE_ALGORITHM_1_1.js
@@ -1,0 +1,1 @@
+ipcRenderer.send('channel', { timeStamp: new Date() });

--- a/test/checks/AtomicChecks/NATIVE_WINDOW_OPEN_CHANGE_1_1.js
+++ b/test/checks/AtomicChecks/NATIVE_WINDOW_OPEN_CHANGE_1_1.js
@@ -1,0 +1,5 @@
+let win = new BrowserWindow({
+  webPreferences: {
+    nativeWindowOpen: true
+  }
+})

--- a/test/checks/AtomicChecks/PRIVILEGED_SCHEMES_REGISTRATION_REMOVAL_1_3.js
+++ b/test/checks/AtomicChecks/PRIVILEGED_SCHEMES_REGISTRATION_REMOVAL_1_3.js
@@ -1,0 +1,3 @@
+webFrame.registerURLSchemeAsPrivileged('baz'); 
+webFrame.registerURLSchemeAsBypassingCSP('foo');
+protocol.registerStandardSchemes(['bar','test']);

--- a/test/checks/AtomicChecks/QUERY_SYSTEM_IDLE_STATE_DEPRECATION_1_1.js
+++ b/test/checks/AtomicChecks/QUERY_SYSTEM_IDLE_STATE_DEPRECATION_1_1.js
@@ -1,0 +1,3 @@
+powerMonitor.querySystemIdleState(30, (currentState) => {
+  console.log(`Idle state is ${currentState}`);
+});

--- a/test/checks/AtomicChecks/QUERY_SYSTEM_IDLE_STATE_REMOVAL_1_1.js
+++ b/test/checks/AtomicChecks/QUERY_SYSTEM_IDLE_STATE_REMOVAL_1_1.js
@@ -1,0 +1,3 @@
+powerMonitor.querySystemIdleState(30, (currentState) => {
+  console.log(`Idle state is ${currentState}`);
+});

--- a/test/checks/AtomicChecks/QUERY_SYSTEM_IDLE_TIME_DEPRECATION_1_1.js
+++ b/test/checks/AtomicChecks/QUERY_SYSTEM_IDLE_TIME_DEPRECATION_1_1.js
@@ -1,0 +1,3 @@
+powerMonitor.querySystemIdleTime((idleTime) => {
+  console.log(`Idle time is ${idleTime}`);
+});

--- a/test/checks/AtomicChecks/QUERY_SYSTEM_IDLE_TIME_REMOVAL_1_1.js
+++ b/test/checks/AtomicChecks/QUERY_SYSTEM_IDLE_TIME_REMOVAL_1_1.js
@@ -1,0 +1,3 @@
+powerMonitor.querySystemIdleTime((idleTime) => {
+  console.log(`Idle time is ${idleTime}`);
+});

--- a/test/checks/AtomicChecks/REQUIRE_ELECTRON_SCREEN_DEPRECATION_1_2.js
+++ b/test/checks/AtomicChecks/REQUIRE_ELECTRON_SCREEN_DEPRECATION_1_2.js
@@ -1,0 +1,2 @@
+const {app, screen} = require('electron');
+const screen2 = require('electron').screen;

--- a/test/checks/AtomicChecks/REQUIRE_SANDBOXED_RENDERERS_DEPRECATION_1_4.js
+++ b/test/checks/AtomicChecks/REQUIRE_SANDBOXED_RENDERERS_DEPRECATION_1_4.js
@@ -1,0 +1,4 @@
+const child = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');

--- a/test/checks/AtomicChecks/SET_HIGHLIGHT_MODE_DEPRECATION_1_1.js
+++ b/test/checks/AtomicChecks/SET_HIGHLIGHT_MODE_DEPRECATION_1_1.js
@@ -1,0 +1,3 @@
+const { Tray } = require('electron');
+const tray = new Tray('/path/to/my/icon');
+tray.setHighlightMode('always');

--- a/test/checks/AtomicChecks/SET_HIGHLIGHT_MODE_REMOVAL_1_1.js
+++ b/test/checks/AtomicChecks/SET_HIGHLIGHT_MODE_REMOVAL_1_1.js
@@ -1,0 +1,3 @@
+const { Tray } = require('electron');
+const tray = new Tray('/path/to/my/icon');
+tray.setHighlightMode('always');

--- a/test/checks/AtomicChecks/SET_NULL_MENU_DEPRECATION_1_1.js
+++ b/test/checks/AtomicChecks/SET_NULL_MENU_DEPRECATION_1_1.js
@@ -1,0 +1,3 @@
+const {BrowserWindow, Menu} = require('electron');
+let win = new BrowserWindow({ width: 800, height: 600 })
+win.setMenu(null);

--- a/test/checks/AtomicChecks/SET_SPELLCHECK_PROVIDER_DEPRECATION_1_1.js
+++ b/test/checks/AtomicChecks/SET_SPELLCHECK_PROVIDER_DEPRECATION_1_1.js
@@ -1,0 +1,5 @@
+webFrame.setSpellCheckProvider('en-US', true, {
+  spellCheck: (text) => {
+    return !spellchecker.isMisspelled(text)
+  }
+})

--- a/test/checks/AtomicChecks/SET_ZOOM_LEVEL_LIMITS_DEPRECATION_1_1.js
+++ b/test/checks/AtomicChecks/SET_ZOOM_LEVEL_LIMITS_DEPRECATION_1_1.js
@@ -1,0 +1,1 @@
+webFrame.setLayoutZoomLevelLimits(1, 3);

--- a/test/checks/AtomicChecks/VISIBLE_ON_FULLSCREEN_DEPRECATION_1_1.js
+++ b/test/checks/AtomicChecks/VISIBLE_ON_FULLSCREEN_DEPRECATION_1_1.js
@@ -1,0 +1,5 @@
+win.setVisibleOnAllWorkspaces(true, {
+  visibleOnFullScreen: true
+});
+
+win.setVisibleOnAllWorkspaces(false);

--- a/test/checks/AtomicChecks/WEBKITDIRECTORY_CHANGE_1_2.html
+++ b/test/checks/AtomicChecks/WEBKITDIRECTORY_CHANGE_1_2.html
@@ -1,0 +1,5 @@
+<input type="file" id="filepicker" name="fileList" webkitdirectory multiple />
+
+<input type="file" id="filepicker2" name="fileList2" />
+
+<input type="file" id="filepicker3" name="fileList3" webkitdirectory />

--- a/test/checks/AtomicChecks/WEB_FRAME_ISOLATED_WORLD_DEPRECATION_1_3.js
+++ b/test/checks/AtomicChecks/WEB_FRAME_ISOLATED_WORLD_DEPRECATION_1_3.js
@@ -1,0 +1,3 @@
+webFrame.setIsolatedWorldContentSecurityPolicy(worldId, csp);
+webFrame.setIsolatedWorldHumanReadableName(worldId, name);
+webFrame.setIsolatedWorldSecurityOrigin(worldId, securityOrigin);

--- a/test/checks/AtomicChecks/WEB_FRAME_ISOLATED_WORLD_REMOVAL_1_3.js
+++ b/test/checks/AtomicChecks/WEB_FRAME_ISOLATED_WORLD_REMOVAL_1_3.js
@@ -1,0 +1,3 @@
+webFrame.setIsolatedWorldContentSecurityPolicy(worldId, csp);
+webFrame.setIsolatedWorldHumanReadableName(worldId, name);
+webFrame.setIsolatedWorldSecurityOrigin(worldId, securityOrigin);

--- a/test/checks/GlobalChecks/ALLOW_RENDERER_PROCESS_REUSE_GLOBAL_DEPRECATION_1_1/ALLOW_RENDERER_PROCESS_REUSE_GLOBAL_DEPRECATION_1_1.js
+++ b/test/checks/GlobalChecks/ALLOW_RENDERER_PROCESS_REUSE_GLOBAL_DEPRECATION_1_1/ALLOW_RENDERER_PROCESS_REUSE_GLOBAL_DEPRECATION_1_1.js
@@ -1,0 +1,4 @@
+const { app } = require('electron');
+app.on('window-all-closed', () => {
+  app.quit();
+});

--- a/test/test_finder.js
+++ b/test/test_finder.js
@@ -23,7 +23,7 @@ logger.add(logger.transports.Console, {colorize : true, level : 'silly'});
 let check_tests = "test/checks/AtomicChecks";
 
 describe('Finder', () => {
-  let finder = new Finder();
+  let finder = new Finder(null, '4..8');
 
   // Load all test files
   let loader = new LoaderFile();

--- a/test/test_globalchecks.js
+++ b/test/test_globalchecks.js
@@ -23,7 +23,8 @@ logger.add(logger.transports.Console, {colorize : true, level : 'silly'});
 let globalcheck_tests = "test/checks/GlobalChecks";
 
 describe('GlobalChecks', async () => {
-  const globalChecker = new GlobalChecks();
+  const electronVersions = '4..8';
+  const globalChecker = new GlobalChecks(null, electronVersions);
   // Load all test file
   let loader = new LoaderDirectory();
   let directories = fs.readdirSync(globalcheck_tests);
@@ -49,7 +50,7 @@ describe('GlobalChecks', async () => {
       var globalCheck = globalChecker._constructed_checks[testedCheck];
 
       // loads the dependencies for the current globalCheck
-      let finder = await new Finder(globalCheck.depends.map(check => check.toLowerCase()));
+      let finder = await new Finder(globalCheck.depends.map(check => check.toLowerCase()), electronVersions);
       // run the checks required by the globalCheck in order to work
       for (let file of filenames) {
             const [type, data, content, warnings] = parser.parse(file, loader.load_buffer(file));


### PR DESCRIPTION
This PR adds the option to run Electron upgrade checks with Electronegativity.  The intention of this feature is for developers to discover the breaking changes that will affect them when they upgrade to a newer version of Electron.

As it currently stands this PR adds checks for Electron versions 5-8.

To use this feature a new argument, `-u` or `--upgrade` is used.  When using this argument, the user will need to pass along a string in the format of `x..y` where x is the user's current version of Electron and y is the user's target version of Electron to upgrade to.  For example for an app that is currently using Electron 4 and trying to upgrade to Electron 8, electronegativity would be invoked as follows:
`electronegativity -i /path/to/electron/app -v -u 4..8`