### PR TITLE
Closes #72: Don't require customScan when running programmatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ run({
   output: '/path/for/output/file',
   // true to save output as sarif, false to save as csv (optional)
   isSarif: false,
-  // only run the specified checks
+  // only run the specified checks (optional)
   customScan: ['dangerousfunctionsjscheck', 'remotemodulejscheck'],
   // only return findings with the specified level of severity or above (optional)
   severitySet: 'high',

--- a/src/runner.js
+++ b/src/runner.js
@@ -49,6 +49,8 @@ export default async function run(options, forCli = false) {
     } else options.confidenceSet = confidence[options.confidenceSet.toUpperCase()];
   } else options.confidenceSet = confidence["TENTATIVE"]; // default to lowest
 
+  options.customScan = (options.customScan || []).map(c => c.toLowerCase());
+
   // Parser
   const parser = new Parser(false, true);
   const globalChecker = new GlobalChecks(options.customScan, options.electronUpgrade);


### PR DESCRIPTION
`input` is now the only required parameter.

Also made sure that the check names can be passed like the actual class names (with uppercase letters).