### PR TITLE
Add options for parser plugins.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ $ electronegativity -h
 | -v, --verbose | show the description for the findings |
 | -u, --upgrade <current version..target version> | run Electron upgrade checks, eg -u 7..8 to check upgrade from Electron 7 to 8 |
 | -e, --electron-version <version> | assume the set Electron version, overriding the detected one, eg -e 7.0.0 to treat as using Electron 7 |
+| -p, --parser-plugins <plugins> | specify additional parser plugins to use separated by commas, e.g. -p optionalChaining |
 | -h, --help   | output usage information                          |
 
 
@@ -89,7 +90,9 @@ run({
   // run Electron upgrade checks, eg -u 7..8 to check upgrade from Electron 7 to 8 (optional)
   electronUpgrade: '7..8',
   // assume the set Electron version, overriding the detected one
-  electronVersion: '5.0.0'
+  electronVersion: '5.0.0',
+  // use additional parser plugins
+  parserPlugins: ['optionalChaining']
 })
     .then(result => console.log(result))
     .catch(err => console.error(err));

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ program
   .option('-v, --verbose', 'show the description for the findings')
   .option('-u, --upgrade <current version..target version>', 'run Electron upgrade checks, eg -u 7..8')
   .option('-e, --electron-version <version>', 'assume the set Electron version, overriding the detected one, eg -e 7.0.0 to treat as using Electron 7')
+  .option('-p, --parser-plugins <plugins>', 'specify additional parser plugins to use separated by commas, e.g. -p optionalChaining')
   .parse(process.argv);
 
 if(!program.input){
@@ -59,6 +60,12 @@ if (typeof program.verbose !== 'undefined' && program.verbose)
 else
   program.verbose = false;
 
+if (typeof program.parserPlugins !== 'undefined' && program.parserPlugins)
+  program.parserPlugins = program.parserPlugins.split(",").map(p => p.trim());
+else
+  program.parserPlugins = [];
+
+
 const input = path.resolve(program.input);
 const forCli = true;
 
@@ -72,5 +79,6 @@ run({
   isRelative: program.relative,
   isVerbose: program.verbose,
   electronUpgrade: program.upgrade,
-  electronVersionOverride: program.electronVersion
+  electronVersionOverride: program.electronVersion,
+  parserPlugins: program.parserPlugins
 }, forCli);

--- a/src/parser/parser.js
+++ b/src/parser/parser.js
@@ -17,6 +17,33 @@ export class Parser {
 
     this.babelFirst = babelFirst;
     this.typescriptBabelFirst = typescriptBabelFirst;
+    this.babelPlugins = [
+      "jsx",
+      "objectRestSpread",
+      "classProperties",
+      "optionalCatchBinding",
+      "asyncGenerators",
+      "decorators-legacy",
+      "flow",
+      "dynamicImport",
+      "estree",
+    ]
+
+    this.tsPlugins = [
+      "jsx",
+      "objectRestSpread",
+      "classProperties",
+      "optionalCatchBinding",
+      "asyncGenerators",
+      "decorators-legacy",
+      "typescript",
+      "dynamicImport",
+    ]
+  }
+
+  addPlugin(plugin) {
+    this.tsPlugins.push(plugin)
+    this.babelPlugins.push(plugin)
   }
 
   parseEsprima(content) {
@@ -27,21 +54,9 @@ export class Parser {
   }
 
   parseBabel(content) {
-    let plugins = [
-      "jsx",
-      "objectRestSpread",
-      "classProperties",
-      "optionalCatchBinding",
-      "asyncGenerators",
-      "decorators-legacy",
-      "flow",
-      "dynamicImport",
-      "estree",
-    ];
-
     let data = babelParser.parse(content, {
       sourceType: "module",
-      plugins: plugins,
+      plugins: this.babelPlugins,
       ecmaFeatures: {
           modules: true
       }
@@ -53,20 +68,9 @@ export class Parser {
   }
 
   parseTypeScript(content) {
-    let plugins = [
-      "jsx",
-      "objectRestSpread",
-      "classProperties",
-      "optionalCatchBinding",
-      "asyncGenerators",
-      "decorators-legacy",
-      "typescript",
-      "dynamicImport"
-    ];
-
     let data = babelParser.parse(content, {
       sourceType: "module",
-      plugins: plugins
+      plugins: this.tsPlugins
     });
 
     data.astParser = this.esLintBabelTreeAst;

--- a/src/runner.js
+++ b/src/runner.js
@@ -57,6 +57,7 @@ export default async function run(options, forCli = false) {
 
   // Parser
   const parser = new Parser(false, true);
+  options.parserPlugins.forEach(plugin => parser.addPlugin(plugin)) 
   const globalChecker = new GlobalChecks(options.customScan, options.electronUpgrade);
   if (options.customScan.length > 0) options.customScan = options.customScan.filter(r => !r.includes('globalcheck')).concat(globalChecker.dependencies);
   const finder = await new Finder(options.customScan, options.electronUpgrade);


### PR DESCRIPTION
This PR is to resolve #74.  It adds an option to specify additional parser plugins on the command line, or programmatically.  Also includes the relevant updates to the README.