### PR TITLE
Fix false positive for global navigation check in typescript

### DIFF
--- a/src/finder/checks/AtomicChecks/CustomArgumentsJSCheck.js
+++ b/src/finder/checks/AtomicChecks/CustomArgumentsJSCheck.js
@@ -44,12 +44,12 @@ export default class CustomArgumentsJSCheck {
     ];
   }
 
-  match(astNode) {
+  match(astNode, astHelper) {
     const methods = ['appendArgument', 'appendSwitch'];
 
     if (astNode.type !== 'CallExpression') return null;
     if ((astNode.callee.name && methods.includes(astNode.callee.name)) || (astNode.callee.property && methods.includes(astNode.callee.property.name))) {
-      if (astNode.arguments && astNode.arguments.length > 0 && (astNode.arguments[0].type === "Literal" || astNode.arguments[0].type === "StringLiteral") && astNode.arguments[0].value) {
+      if (astNode.arguments && astNode.arguments.length > 0 && astNode.arguments[0].type === astHelper.StringLiteral && astNode.arguments[0].value) {
         var res = this.dangerousArguments.some(function(arg) {
           return astNode.arguments[0].value.includes(arg);
         });

--- a/src/finder/checks/AtomicChecks/LimitNavigationJSCheck.js
+++ b/src/finder/checks/AtomicChecks/LimitNavigationJSCheck.js
@@ -9,12 +9,13 @@ export default class LimitNavigationJSCheck {
     this.shortenedURL = "https://git.io/JeuM3";
   }
 
-  match(astNode){
+  match(astNode, astHelper){
+
     if (astNode.type !== 'CallExpression') return null;
     if (astNode.callee.property && astNode.callee.property.name === "on") {
       if (astNode.arguments && astNode.arguments.length > 1) {
         var eventValue = astNode.arguments[0].value;
-        if (astNode.arguments[0].type === "Literal" && (eventValue === "will-navigate" || eventValue === "new-window")) {
+        if (astNode.arguments[0].type === astHelper.StringLiteral && (eventValue === "will-navigate" || eventValue === "new-window")) {
           return [{ line: astNode.loc.start.line, column: astNode.loc.start.column, id: this.id, description: this.description, shortenedURL: this.shortenedURL, severity: severity.HIGH, confidence: confidence.TENTATIVE, manualReview: true }];
         }
       }

--- a/test/checks/AtomicChecks/LIMIT_NAVIGATION_JS_CHECK_1_2.ts
+++ b/test/checks/AtomicChecks/LIMIT_NAVIGATION_JS_CHECK_1_2.ts
@@ -1,0 +1,5 @@
+export const create: CreateBrowserWindow = ({ isDev, options }) => {
+  newWindow.webContents.on("will-navigate", event => event.preventDefault());
+  newWindow.webContents.on("new-window", event => event.preventDefault());
+  return newWindow;
+};


### PR DESCRIPTION
Typescript code would always have the LIMIT_NAVIGATION_GLOBAL_CHECK fail.  This was happening because the atomic LIMIT_NAVIGATION_JS_CHECK was looking for an AST node of type Literal, instead of using AstHelper.StringLiteral.  As a result, the check worked properly for javascript code but not typescript.

This PR:

- fixes this particular issue
- adds a test case
- makes the coding style consistent across the CustomArgumentsJSCheck as well