### PR TITLE
fix: use `parserPlugins` only if they provided

### DIFF
--- a/src/runner.js
+++ b/src/runner.js
@@ -60,7 +60,10 @@ export default async function run(options, forCli = false) {
 
   // Parser options initialization
   const parser = new Parser(false, true);
-  options.parserPlugins.forEach(plugin => parser.addPlugin(plugin)) 
+
+  if (options.parserPlugins.length > 0) {
+    options.parserPlugins.forEach(plugin => parser.addPlugin(plugin));
+  }
 
   // Global Checker initialization
   const globalChecker = new GlobalChecks(options.customScan, options.excludeFromScan, options.electronUpgrade);


### PR DESCRIPTION
This PR fixes the programmatic usage which by default doesn't have a `parserPlugins` option, by adding them only if this option is provided