### PR TITLE
fix: update mocha dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "ini": "^1.3.8",
     "linenumber": "^1.0.1",
     "lodash": "^4.17.21",
-    "mocha": "^8.4.0",
+    "mocha": "^10.1.0",
     "node-dir": "^0.1.17",
     "read-package-tree": "^5.3.1",
     "semver": "^7.3.5",


### PR DESCRIPTION
This was throwing up flags in a `yarn audit` output.  This bumps the minimum node version to >=14 which is current LTS anyway